### PR TITLE
● feat(front): migrate fetchApi to ofetch with 401 interceptor

### DIFF
--- a/assets/shared/api/fetchApi.ts
+++ b/assets/shared/api/fetchApi.ts
@@ -1,24 +1,21 @@
-const API_BASE = '/api/admin'
+import { ofetch } from 'ofetch'
 
-export async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<T> {
-  const token = localStorage.getItem('admin_token')
+const fetchApi = ofetch.create({
+  baseURL: '/api/admin',
+  onRequest({ options }) {
+    const token = localStorage.getItem('admin_token')
+    if (token) {
+      const headers = new Headers(options.headers as HeadersInit)
+      headers.set('Authorization', `Bearer ${token}`)
+      options.headers = headers
+    }
+  },
+  onResponseError({ response }) {
+    if (response.status === 401 && window.location.pathname !== '/admin/login') {
+      localStorage.removeItem('admin_token')
+      window.location.href = '/admin/login'
+    }
+  },
+})
 
-  const response = await fetch(`${API_BASE}${endpoint}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...options?.headers,
-    },
-    ...options,
-  })
-
-  if (!response.ok) {
-    throw new Error(`API Error: ${response.status} ${response.statusText}`)
-  }
-
-  if (response.status === 204 || response.status === 205) {
-    return undefined as T
-  }
-
-  return response.json()
-}
+export { fetchApi }

--- a/config/services/summoner.yaml
+++ b/config/services/summoner.yaml
@@ -1,6 +1,6 @@
 services:
     App\Summoner\Domain\Repository\SummonerRepositoryInterface:
         alias: App\Summoner\Infrastructure\Persistence\Doctrine\Repository\DoctrineSummonerRepository
-
-    App\Summoner\Application\Port\RiotSummonerAdapterInterface:
+    
+    App\Summoner\Application\Port\RiotSummonerProviderInterface:
         alias: App\Summoner\Infrastructure\Adapter\RiotSummonerProvider

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.0",
     "chart.js": "^4.5.1",
+    "ofetch": "^1.5.1",
     "pinia": "^2.1.0",
     "tailwindcss": "^4.2.0",
     "vue": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,6 +875,11 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+destr@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/destr/-/destr-2.0.5.tgz#7d112ff1b925fb8d2079fac5bdb4a90973b51fdb"
+  integrity sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==
+
 detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
@@ -1367,12 +1372,26 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+node-fetch-native@^1.6.7:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.7.tgz#9d09ca63066cc48423211ed4caf5d70075d76a71"
+  integrity sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==
+
 nth-check@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"
+
+ofetch@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/ofetch/-/ofetch-1.5.1.tgz#5c43cc56e03398b273014957060344254505c5c7"
+  integrity sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==
+  dependencies:
+    destr "^2.0.5"
+    node-fetch-native "^1.6.7"
+    ufo "^1.6.1"
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -1622,6 +1641,11 @@ typescript@^5.3.0:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+ufo@^1.6.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.3.tgz#799666e4e88c122a9659805e30b9dc071c3aed4f"
+  integrity sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Replace native fetch wrapper with ofetch to centralize HTTP concerns. 
Injects JWT token on every request and redirects to login on expired token (401).