### PR TITLE
feat(match): enrichir les stats des participants avec ParticipantStats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,9 @@ jobs:
         name: PHP CS Fixer
         run: docker run --rm -v $(pwd):/project -w /project jakzal/phpqa:php8.4-alpine php-cs-fixer fix --dry-run --diff --verbose
       -
+        name: Install PHP dependencies
+        run: docker run --rm -v $(pwd):/project -w /project jakzal/phpqa:php8.4-alpine composer install --no-interaction --prefer-dist
+      -
         name: PHPStan
         run: docker run --rm -v $(pwd):/project -w /project jakzal/phpqa:php8.4-alpine phpstan analyse --memory-limit=1G
       -

--- a/assets/admin/views/MatchDetail.vue
+++ b/assets/admin/views/MatchDetail.vue
@@ -4,6 +4,7 @@ import { useRoute, RouterLink } from 'vue-router'
 import { api } from '@shared/api/client'
 import type { Match } from '@shared/types'
 import ChampionIcon from '@shared/components/ChampionIcon.vue'
+import ItemIcon from '@shared/components/ItemIcon.vue'
 
 const route = useRoute()
 const match = ref<Match | null>(null)
@@ -34,6 +35,10 @@ function formatDate(dateString: string): string {
     hour: '2-digit',
     minute: '2-digit',
   })
+}
+
+function formatGold(value: number): string {
+  return value.toLocaleString('fr-FR')
 }
 </script>
 
@@ -75,30 +80,60 @@ function formatDate(dateString: string): string {
           <h3>Winners</h3>
           <span class="badge bg-lol-win text-white">Victory</span>
         </div>
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Champion</th>
-              <th>K/D/A</th>
-              <th>KDA Ratio</th>
-              <th>Summoner</th>
-              <th>Name</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="participant in winners" :key="participant.puuid">
-              <td><ChampionIcon :champion-id="participant.championId" :size="36" /></td>
-              <td>{{ participant.kills }}/{{ participant.deaths }}/{{ participant.assists }}</td>
-              <td>{{ participant.kda }}</td>
-              <td>{{ participant.gameName }}</td>
-              <td>
-                <RouterLink :to="`/summoners/${participant.summonerId}`">
-                  {{ participant.summonerId.substring(0, 8) }}...
-                </RouterLink>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="table-wrapper">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Champion</th>
+                <th>Summoner</th>
+                <th>Lvl</th>
+                <th>K/D/A</th>
+                <th>KDA</th>
+                <th>CS</th>
+                <th>Gold</th>
+                <th>Dmg dealt</th>
+                <th>Dmg taken</th>
+                <th>Vision</th>
+                <th>Wards</th>
+                <th>Items</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="participant in winners" :key="participant.puuid">
+                <td><ChampionIcon :champion-id="participant.championId" :size="36" /></td>
+                <td>
+                  <div>{{ participant.gameName }}</div>
+                  <RouterLink
+                    :to="`/summoners/${participant.summonerId}`"
+                    class="text-muted text-sm"
+                  >
+                    {{ participant.summonerId.substring(0, 8) }}...
+                  </RouterLink>
+                </td>
+                <td>{{ participant.champLevel }}</td>
+                <td>{{ participant.kills }}/{{ participant.deaths }}/{{ participant.assists }}</td>
+                <td>{{ participant.kda }}</td>
+                <td>{{ participant.cs }}</td>
+                <td>{{ formatGold(participant.goldEarned) }}</td>
+                <td>{{ formatGold(participant.totalDamageDealtToChampions) }}</td>
+                <td>{{ formatGold(participant.totalDamageTaken) }}</td>
+                <td>{{ participant.visionScore }}</td>
+                <td>{{ participant.wardsPlaced }}/{{ participant.wardsKilled }}</td>
+                <td>
+                  <div class="items-row">
+                    <ItemIcon
+                      v-for="itemId in participant.items"
+                      :key="itemId"
+                      :item-id="itemId"
+                      :version="match.version"
+                      :size="28"
+                    />
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
 
       <div class="card">
@@ -106,31 +141,81 @@ function formatDate(dateString: string): string {
           <h3>Losers</h3>
           <span class="badge bg-lol-loss text-white">Defeat</span>
         </div>
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Champion</th>
-              <th>K/D/A</th>
-              <th>KDA Ratio</th>
-              <th>Summoner</th>
-              <th>Name</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="participant in losers" :key="participant.puuid">
-              <td><ChampionIcon :champion-id="participant.championId" :size="36" /></td>
-              <td>{{ participant.kills }}/{{ participant.deaths }}/{{ participant.assists }}</td>
-              <td>{{ participant.kda }}</td>
-              <td>{{ participant.gameName }}</td>
-              <td>
-                <RouterLink :to="`/summoners/${participant.summonerId}`">
-                  {{ participant.summonerId.substring(0, 8) }}...
-                </RouterLink>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="table-wrapper">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Champion</th>
+                <th>Summoner</th>
+                <th>Lvl</th>
+                <th>K/D/A</th>
+                <th>KDA</th>
+                <th>CS</th>
+                <th>Gold</th>
+                <th>Dmg dealt</th>
+                <th>Dmg taken</th>
+                <th>Vision</th>
+                <th>Wards</th>
+                <th>Items</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="participant in losers" :key="participant.puuid">
+                <td><ChampionIcon :champion-id="participant.championId" :size="36" /></td>
+                <td>
+                  <div>{{ participant.gameName }}</div>
+                  <RouterLink
+                    :to="`/summoners/${participant.summonerId}`"
+                    class="text-muted text-sm"
+                  >
+                    {{ participant.summonerId.substring(0, 8) }}...
+                  </RouterLink>
+                </td>
+                <td>{{ participant.champLevel }}</td>
+                <td>{{ participant.kills }}/{{ participant.deaths }}/{{ participant.assists }}</td>
+                <td>{{ participant.kda }}</td>
+                <td>{{ participant.cs }}</td>
+                <td>{{ formatGold(participant.goldEarned) }}</td>
+                <td>{{ formatGold(participant.totalDamageDealtToChampions) }}</td>
+                <td>{{ formatGold(participant.totalDamageTaken) }}</td>
+                <td>{{ participant.visionScore }}</td>
+                <td>{{ participant.wardsPlaced }}/{{ participant.wardsKilled }}</td>
+                <td>
+                  <div class="items-row">
+                    <ItemIcon
+                      v-for="itemId in participant.items"
+                      :key="itemId"
+                      :item-id="itemId"
+                      :version="match.version"
+                      :size="28"
+                    />
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.items-row {
+  display: flex;
+  gap: 2px;
+  flex-wrap: wrap;
+}
+
+.text-muted {
+  color: var(--lol-muted, #8a9bb2);
+}
+
+.text-sm {
+  font-size: 0.75rem;
+}
+</style>

--- a/assets/front/views/MatchDetail.vue
+++ b/assets/front/views/MatchDetail.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import { useRoute, RouterLink } from 'vue-router'
 import { api } from '@shared/api/client'
 import type { Match } from '@shared/types'
+import ItemIcon from '@shared/components/ItemIcon.vue'
 
 const route = useRoute()
 const match = ref<Match | null>(null)
@@ -33,6 +34,10 @@ function formatDate(dateString: string): string {
     hour: '2-digit',
     minute: '2-digit',
   })
+}
+
+function formatGold(value: number): string {
+  return value.toLocaleString('fr-FR')
 }
 </script>
 
@@ -74,16 +79,22 @@ function formatDate(dateString: string): string {
           <thead>
             <tr>
               <th>Champion</th>
-              <th>K/D/A</th>
-              <th>KDA Ratio</th>
               <th>Summoner</th>
+              <th>Lvl</th>
+              <th>K/D/A</th>
+              <th>KDA</th>
+              <th>CS</th>
+              <th>Gold</th>
+              <th>Dmg dealt</th>
+              <th>Dmg taken</th>
+              <th>Vision</th>
+              <th>Wards</th>
+              <th>Items</th>
             </tr>
           </thead>
           <tbody>
             <tr v-for="participant in winners" :key="participant.puuid">
               <td>Champion #{{ participant.championId }}</td>
-              <td>{{ participant.kills }}/{{ participant.deaths }}/{{ participant.assists }}</td>
-              <td>{{ participant.kda }}</td>
               <td>
                 <RouterLink
                   :to="`/summoners/${participant.puuid}`"
@@ -91,6 +102,26 @@ function formatDate(dateString: string): string {
                 >
                   {{ participant.puuid.substring(0, 8) }}...
                 </RouterLink>
+              </td>
+              <td>{{ participant.champLevel }}</td>
+              <td>{{ participant.kills }}/{{ participant.deaths }}/{{ participant.assists }}</td>
+              <td>{{ participant.kda }}</td>
+              <td>{{ participant.cs }}</td>
+              <td>{{ formatGold(participant.goldEarned) }}</td>
+              <td>{{ formatGold(participant.totalDamageDealtToChampions) }}</td>
+              <td>{{ formatGold(participant.totalDamageTaken) }}</td>
+              <td>{{ participant.visionScore }}</td>
+              <td>{{ participant.wardsPlaced }}/{{ participant.wardsKilled }}</td>
+              <td>
+                <div class="items-row">
+                  <ItemIcon
+                    v-for="itemId in participant.items"
+                    :key="itemId"
+                    :item-id="itemId"
+                    :version="match.version"
+                    :size="28"
+                  />
+                </div>
               </td>
             </tr>
           </tbody>
@@ -106,16 +137,22 @@ function formatDate(dateString: string): string {
           <thead>
             <tr>
               <th>Champion</th>
-              <th>K/D/A</th>
-              <th>KDA Ratio</th>
               <th>Summoner</th>
+              <th>Lvl</th>
+              <th>K/D/A</th>
+              <th>KDA</th>
+              <th>CS</th>
+              <th>Gold</th>
+              <th>Dmg dealt</th>
+              <th>Dmg taken</th>
+              <th>Vision</th>
+              <th>Wards</th>
+              <th>Items</th>
             </tr>
           </thead>
           <tbody>
             <tr v-for="participant in losers" :key="participant.puuid">
               <td>Champion #{{ participant.championId }}</td>
-              <td>{{ participant.kills }}/{{ participant.deaths }}/{{ participant.assists }}</td>
-              <td>{{ participant.kda }}</td>
               <td>
                 <RouterLink
                   :to="`/summoners/${participant.puuid}`"
@@ -124,6 +161,26 @@ function formatDate(dateString: string): string {
                   {{ participant.puuid.substring(0, 8) }}...
                 </RouterLink>
               </td>
+              <td>{{ participant.champLevel }}</td>
+              <td>{{ participant.kills }}/{{ participant.deaths }}/{{ participant.assists }}</td>
+              <td>{{ participant.kda }}</td>
+              <td>{{ participant.cs }}</td>
+              <td>{{ formatGold(participant.goldEarned) }}</td>
+              <td>{{ formatGold(participant.totalDamageDealtToChampions) }}</td>
+              <td>{{ formatGold(participant.totalDamageTaken) }}</td>
+              <td>{{ participant.visionScore }}</td>
+              <td>{{ participant.wardsPlaced }}/{{ participant.wardsKilled }}</td>
+              <td>
+                <div class="items-row">
+                  <ItemIcon
+                    v-for="itemId in participant.items"
+                    :key="itemId"
+                    :item-id="itemId"
+                    :version="match.version"
+                    :size="28"
+                  />
+                </div>
+              </td>
             </tr>
           </tbody>
         </table>
@@ -131,3 +188,11 @@ function formatDate(dateString: string): string {
     </div>
   </div>
 </template>
+
+<style scoped>
+.items-row {
+  display: flex;
+  gap: 2px;
+  flex-wrap: wrap;
+}
+</style>

--- a/assets/shared/components/ItemIcon.vue
+++ b/assets/shared/components/ItemIcon.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    itemId: string
+    version: string
+    size?: number
+  }>(),
+  { size: 32 },
+)
+
+const imageUrl = `https://ddragon.leagueoflegends.com/cdn/${props.version}/img/item/${props.itemId}.png`
+</script>
+
+<template>
+  <div class="item-icon" :style="{ width: `${size}px`, height: `${size}px` }">
+    <img
+      :src="imageUrl"
+      :alt="`Item ${itemId}`"
+      :title="`Item ${itemId}`"
+      :width="size"
+      :height="size"
+      class="item-icon__img"
+    />
+  </div>
+</template>
+
+<style scoped>
+.item-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.item-icon__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid rgba(200, 155, 60, 0.4);
+}
+</style>

--- a/assets/shared/types/index.ts
+++ b/assets/shared/types/index.ts
@@ -23,8 +23,21 @@ export interface Participant {
   assists: number
   kda: string
   win: boolean
-  items: string[]
   gameName: string | null
+  cs: number
+  goldEarned: number
+  totalDamageDealtToChampions: number
+  totalDamageTaken: number
+  visionScore: number
+  lane: string
+  individualPosition: string
+  summoner1Id: number
+  summoner2Id: number
+  champLevel: number
+  wardsPlaced: number
+  wardsKilled: number
+  firstBloodKill: boolean
+  items: string[]
 }
 
 export interface Summoner {

--- a/migrations/Version20260316124758.php
+++ b/migrations/Version20260316124758.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260316124758 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE participant_stats (id INT AUTO_INCREMENT NOT NULL, participant_id INT NOT NULL, cs INT NOT NULL, gold_earned INT NOT NULL, total_damage_dealt_to_champions INT NOT NULL, total_damage_taken INT NOT NULL, vision_score INT NOT NULL, lane VARCHAR(50) NOT NULL, individual_position VARCHAR(50) NOT NULL, summoner1_id INT NOT NULL, summoner2_id INT NOT NULL, champ_level INT NOT NULL, wards_placed INT NOT NULL, wards_killed INT NOT NULL, first_blood_kill TINYINT(1) NOT NULL, items JSON NOT NULL, UNIQUE INDEX UNIQ_96F2CE139D1C3019 (participant_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE participant_stats ADD CONSTRAINT FK_96F2CE139D1C3019 FOREIGN KEY (participant_id) REFERENCES participants (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE participant_stats DROP FOREIGN KEY FK_96F2CE139D1C3019');
+        $this->addSql('DROP TABLE participant_stats');
+    }
+}

--- a/src/Match/Application/ReadModel/ParticipantReadModel.php
+++ b/src/Match/Application/ReadModel/ParticipantReadModel.php
@@ -20,14 +20,28 @@ final readonly class ParticipantReadModel
         public int $assists,
         public string $kda,
         public bool $win,
-        public array $items,
         public ?string $gameName,
+        public int $cs,
+        public int $goldEarned,
+        public int $totalDamageDealtToChampions,
+        public int $totalDamageTaken,
+        public int $visionScore,
+        public string $lane,
+        public string $individualPosition,
+        public int $summoner1Id,
+        public int $summoner2Id,
+        public int $champLevel,
+        public int $wardsPlaced,
+        public int $wardsKilled,
+        public bool $firstBloodKill,
+        public array $items,
     ) {
     }
 
     public static function fromDomain(Participant $participant, ?string $gameName = null): self
     {
         $kda = $participant->kda();
+        $stats = $participant->stats();
 
         return new self(
             puuid: $participant->puuid(),
@@ -38,8 +52,21 @@ final readonly class ParticipantReadModel
             assists: $kda->assists(),
             kda: 0 === $kda->deaths() ? 'Perfect' : number_format(($kda->kills() + $kda->assists()) / $kda->deaths(), 2),
             win: $participant->win(),
-            items: $participant->items(),
             gameName: $gameName,
+            cs: $stats->cs(),
+            goldEarned: $stats->goldEarned(),
+            totalDamageDealtToChampions: $stats->totalDamageDealtToChampions(),
+            totalDamageTaken: $stats->totalDamageTaken(),
+            visionScore: $stats->visionScore(),
+            lane: $stats->lane(),
+            individualPosition: $stats->individualPosition(),
+            summoner1Id: $stats->summoner1Id(),
+            summoner2Id: $stats->summoner2Id(),
+            champLevel: $stats->champLevel(),
+            wardsPlaced: $stats->wardsPlaced(),
+            wardsKilled: $stats->wardsKilled(),
+            firstBloodKill: $stats->firstBloodKill(),
+            items: $stats->items(),
         );
     }
 }

--- a/src/Match/Domain/Model/Participant.php
+++ b/src/Match/Domain/Model/Participant.php
@@ -9,16 +9,13 @@ use App\Match\Domain\ValueObjet\SummonerPuuid;
 
 final class Participant
 {
-    /**
-     * @param string[] $items
-     */
     public function __construct(
         private readonly SummonerPuuid $summonerPuuid,
         private readonly string $puuid,
         private readonly int $championId,
         private readonly bool $win,
         private readonly KDA $kda,
-        private readonly array $items
+        private readonly ParticipantStats $stats,
     ) {
         if ($championId <= 0) {
             throw new \InvalidArgumentException('championId must be positive');
@@ -45,12 +42,9 @@ final class Participant
         return $this->kda;
     }
 
-    /**
-     * @return string[]
-     */
-    public function items(): array
+    public function stats(): ParticipantStats
     {
-        return $this->items;
+        return $this->stats;
     }
 
     public function puuid(): string

--- a/src/Match/Domain/Model/ParticipantStats.php
+++ b/src/Match/Domain/Model/ParticipantStats.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Match\Domain\Model;
+
+final class ParticipantStats
+{
+    /**
+     * @param string[] $items
+     */
+    public function __construct(
+        private readonly int $cs,
+        private readonly int $goldEarned,
+        private readonly int $totalDamageDealtToChampions,
+        private readonly int $totalDamageTaken,
+        private readonly int $visionScore,
+        private readonly string $lane,
+        private readonly string $individualPosition,
+        private readonly int $summoner1Id,
+        private readonly int $summoner2Id,
+        private readonly int $champLevel,
+        private readonly int $wardsPlaced,
+        private readonly int $wardsKilled,
+        private readonly bool $firstBloodKill,
+        private readonly array $items,
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self(
+            cs: 0,
+            goldEarned: 0,
+            totalDamageDealtToChampions: 0,
+            totalDamageTaken: 0,
+            visionScore: 0,
+            lane: '',
+            individualPosition: '',
+            summoner1Id: 0,
+            summoner2Id: 0,
+            champLevel: 1,
+            wardsPlaced: 0,
+            wardsKilled: 0,
+            firstBloodKill: false,
+            items: [],
+        );
+    }
+
+    public function cs(): int
+    {
+        return $this->cs;
+    }
+
+    public function goldEarned(): int
+    {
+        return $this->goldEarned;
+    }
+
+    public function totalDamageDealtToChampions(): int
+    {
+        return $this->totalDamageDealtToChampions;
+    }
+
+    public function totalDamageTaken(): int
+    {
+        return $this->totalDamageTaken;
+    }
+
+    public function visionScore(): int
+    {
+        return $this->visionScore;
+    }
+
+    public function lane(): string
+    {
+        return $this->lane;
+    }
+
+    public function individualPosition(): string
+    {
+        return $this->individualPosition;
+    }
+
+    public function summoner1Id(): int
+    {
+        return $this->summoner1Id;
+    }
+
+    public function summoner2Id(): int
+    {
+        return $this->summoner2Id;
+    }
+
+    public function champLevel(): int
+    {
+        return $this->champLevel;
+    }
+
+    public function wardsPlaced(): int
+    {
+        return $this->wardsPlaced;
+    }
+
+    public function wardsKilled(): int
+    {
+        return $this->wardsKilled;
+    }
+
+    public function firstBloodKill(): bool
+    {
+        return $this->firstBloodKill;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function items(): array
+    {
+        return $this->items;
+    }
+}

--- a/src/Match/Factory/MatcheFactory.php
+++ b/src/Match/Factory/MatcheFactory.php
@@ -6,6 +6,7 @@ namespace App\Match\Factory;
 
 use App\Match\Domain\Model\Matche;
 use App\Match\Domain\Model\Participant;
+use App\Match\Domain\Model\ParticipantStats;
 use App\Match\Domain\ValueObjet\GameId;
 use App\Match\Domain\ValueObjet\KDA;
 use App\Match\Domain\ValueObjet\MatchId;
@@ -64,13 +65,30 @@ final class MatcheFactory
                 }
             }
 
+            $stats = new ParticipantStats(
+                cs: (int) ($p['totalMinionsKilled'] ?? 0) + (int) ($p['neutralMinionsKilled'] ?? 0),
+                goldEarned: (int) ($p['goldEarned'] ?? 0),
+                totalDamageDealtToChampions: (int) ($p['totalDamageDealtToChampions'] ?? 0),
+                totalDamageTaken: (int) ($p['totalDamageTaken'] ?? 0),
+                visionScore: (int) ($p['visionScore'] ?? 0),
+                lane: (string) ($p['lane'] ?? ''),
+                individualPosition: (string) ($p['individualPosition'] ?? ''),
+                summoner1Id: (int) ($p['summoner1Id'] ?? 0),
+                summoner2Id: (int) ($p['summoner2Id'] ?? 0),
+                champLevel: (int) ($p['champLevel'] ?? 1),
+                wardsPlaced: (int) ($p['wardsPlaced'] ?? 0),
+                wardsKilled: (int) ($p['wardsKilled'] ?? 0),
+                firstBloodKill: (bool) ($p['firstBloodKill'] ?? false),
+                items: $items,
+            );
+
             $participant = new Participant(
-                $summonerPuuid,
-                $p['summonerId'],
-                (int) ($p['championId'] ?? $p['champion']),
-                (bool) ($p['win'] ?? false),
-                $kda,
-                $items
+                summonerPuuid: $summonerPuuid,
+                puuid: $p['summonerId'],
+                championId: (int) ($p['championId'] ?? $p['champion']),
+                win: (bool) ($p['win'] ?? false),
+                kda: $kda,
+                stats: $stats,
             );
             $participants[] = $participant;
         }

--- a/src/Match/Infrastructure/Persistence/Doctrine/Entity/ParticipantEntity.php
+++ b/src/Match/Infrastructure/Persistence/Doctrine/Entity/ParticipantEntity.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Match\Infrastructure\Persistence\Doctrine\Entity;
 
 use App\Match\Domain\Model\Participant;
+use App\Match\Domain\Model\ParticipantStats;
 use App\Match\Domain\ValueObjet\KDA;
 use App\Match\Domain\ValueObjet\SummonerPuuid;
 use App\Summoner\Infrastructure\Persistence\Doctrine\Entity\SummonerEntity;
@@ -49,6 +50,9 @@ class ParticipantEntity
     #[ORM\JoinColumn(name: 'summoner_puuid', referencedColumnName: 'puuid', nullable: true, onDelete: 'SET NULL')]
     private ?SummonerEntity $summoner = null;
 
+    #[ORM\OneToOne(targetEntity: ParticipantStatsEntity::class, mappedBy: 'participant', fetch: 'LAZY', cascade: ['persist'])]
+    public ?ParticipantStatsEntity $stats = null;
+
     public static function fromDomain(Participant $participant, MatchEntity $matchEntity): self
     {
         $entity = new self();
@@ -60,6 +64,7 @@ class ParticipantEntity
         $entity->kills = $participant->kda()->kills();
         $entity->deaths = $participant->kda()->deaths();
         $entity->assists = $participant->kda()->assists();
+        $entity->stats = ParticipantStatsEntity::fromDomain($participant->stats(), $entity);
 
         return $entity;
     }
@@ -67,16 +72,12 @@ class ParticipantEntity
     public function toDomain(): Participant
     {
         return new Participant(
-            SummonerPuuid::fromString($this->summonerId),
-            $this->puuid,
-            $this->championId,
-            $this->win,
-            new KDA(
-                $this->kills,
-                $this->deaths,
-                $this->assists
-            ),
-            []
+            summonerPuuid: SummonerPuuid::fromString($this->summonerId),
+            puuid: $this->puuid,
+            championId: $this->championId,
+            win: $this->win,
+            kda: new KDA($this->kills, $this->deaths, $this->assists),
+            stats: null !== $this->stats ? $this->stats->toDomain() : ParticipantStats::empty(),
         );
     }
 

--- a/src/Match/Infrastructure/Persistence/Doctrine/Entity/ParticipantStatsEntity.php
+++ b/src/Match/Infrastructure/Persistence/Doctrine/Entity/ParticipantStatsEntity.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Match\Infrastructure\Persistence\Doctrine\Entity;
+
+use App\Match\Domain\Model\ParticipantStats;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'participant_stats')]
+class ParticipantStatsEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
+
+    #[ORM\OneToOne(targetEntity: ParticipantEntity::class, inversedBy: 'stats')]
+    #[ORM\JoinColumn(name: 'participant_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    public ParticipantEntity $participant;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $cs = 0;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $goldEarned = 0;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $totalDamageDealtToChampions = 0;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $totalDamageTaken = 0;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $visionScore = 0;
+
+    #[ORM\Column(type: Types::STRING, length: 50)]
+    public string $lane = '';
+
+    #[ORM\Column(type: Types::STRING, length: 50)]
+    public string $individualPosition = '';
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $summoner1Id = 0;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $summoner2Id = 0;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $champLevel = 1;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $wardsPlaced = 0;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $wardsKilled = 0;
+
+    #[ORM\Column(type: Types::BOOLEAN)]
+    public bool $firstBloodKill = false;
+
+    /** @var string[] */
+    #[ORM\Column(type: Types::JSON)]
+    public array $items = [];
+
+    public static function fromDomain(ParticipantStats $stats, ParticipantEntity $participant): self
+    {
+        $entity = new self();
+        $entity->participant = $participant;
+        $entity->cs = $stats->cs();
+        $entity->goldEarned = $stats->goldEarned();
+        $entity->totalDamageDealtToChampions = $stats->totalDamageDealtToChampions();
+        $entity->totalDamageTaken = $stats->totalDamageTaken();
+        $entity->visionScore = $stats->visionScore();
+        $entity->lane = $stats->lane();
+        $entity->individualPosition = $stats->individualPosition();
+        $entity->summoner1Id = $stats->summoner1Id();
+        $entity->summoner2Id = $stats->summoner2Id();
+        $entity->champLevel = $stats->champLevel();
+        $entity->wardsPlaced = $stats->wardsPlaced();
+        $entity->wardsKilled = $stats->wardsKilled();
+        $entity->firstBloodKill = $stats->firstBloodKill();
+        $entity->items = $stats->items();
+
+        return $entity;
+    }
+
+    public function toDomain(): ParticipantStats
+    {
+        return new ParticipantStats(
+            cs: $this->cs,
+            goldEarned: $this->goldEarned,
+            totalDamageDealtToChampions: $this->totalDamageDealtToChampions,
+            totalDamageTaken: $this->totalDamageTaken,
+            visionScore: $this->visionScore,
+            lane: $this->lane,
+            individualPosition: $this->individualPosition,
+            summoner1Id: $this->summoner1Id,
+            summoner2Id: $this->summoner2Id,
+            champLevel: $this->champLevel,
+            wardsPlaced: $this->wardsPlaced,
+            wardsKilled: $this->wardsKilled,
+            firstBloodKill: $this->firstBloodKill,
+            items: $this->items,
+        );
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/src/Match/Infrastructure/Persistence/Doctrine/Repository/DoctrineMatchRepository.php
+++ b/src/Match/Infrastructure/Persistence/Doctrine/Repository/DoctrineMatchRepository.php
@@ -114,7 +114,7 @@ final class DoctrineMatchRepository implements MatchRepositoryInterface
     {
         $entities = $this->em->getRepository(MatchEntity::class)
             ->createQueryBuilder('m')
-            ->orderBy('m.id', 'DESC')
+            ->orderBy('m.playedAt', 'DESC')
             ->setFirstResult($offset)
             ->setMaxResults($limit)
             ->getQuery()

--- a/tests/Factory/ParticipantEntityFactory.php
+++ b/tests/Factory/ParticipantEntityFactory.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Tests\Factory;
 
+use App\Match\Domain\Model\ParticipantStats;
 use App\Match\Infrastructure\Persistence\Doctrine\Entity\MatchEntity;
 use App\Match\Infrastructure\Persistence\Doctrine\Entity\ParticipantEntity;
+use App\Match\Infrastructure\Persistence\Doctrine\Entity\ParticipantStatsEntity;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 
 /**
@@ -29,6 +31,15 @@ final class ParticipantEntityFactory extends PersistentProxyObjectFactory
             'assists' => self::faker()->numberBetween(0, 40),
             'win' => self::faker()->boolean(),
         ];
+    }
+
+    protected function initialize(): static
+    {
+        return $this->afterInstantiate(function (ParticipantEntity $entity): void {
+            if (null === $entity->stats) {
+                $entity->stats = ParticipantStatsEntity::fromDomain(ParticipantStats::empty(), $entity);
+            }
+        });
     }
 
     public function withMatch(MatchEntity $match): self

--- a/tests/Unit/Match/Application/QueryHandler/GetMatchByIdHandlerTest.php
+++ b/tests/Unit/Match/Application/QueryHandler/GetMatchByIdHandlerTest.php
@@ -10,6 +10,7 @@ use App\Match\Application\QueryHandler\GetMatchByIdHandler;
 use App\Match\Application\ReadModel\MatchDetailReadModel;
 use App\Match\Domain\Model\Matche;
 use App\Match\Domain\Model\Participant;
+use App\Match\Domain\Model\ParticipantStats;
 use App\Match\Domain\Repository\MatchRepositoryInterface;
 use App\Match\Domain\ValueObjet\GameId;
 use App\Match\Domain\ValueObjet\KDA;
@@ -42,7 +43,7 @@ final class GetMatchByIdHandlerTest extends TestCase
             championId: 157,
             win: true,
             kda: new KDA(10, 5, 15),
-            items: []
+            stats: ParticipantStats::empty(),
         );
 
         $expectedMatch = new Matche(

--- a/tests/Unit/Match/Application/QueryHandler/ListMatchesHandlerTest.php
+++ b/tests/Unit/Match/Application/QueryHandler/ListMatchesHandlerTest.php
@@ -9,6 +9,7 @@ use App\Match\Application\QueryHandler\ListMatchesHandler;
 use App\Match\Application\ReadModel\MatchReadModel;
 use App\Match\Domain\Model\Matche;
 use App\Match\Domain\Model\Participant;
+use App\Match\Domain\Model\ParticipantStats;
 use App\Match\Domain\Repository\MatchRepositoryInterface;
 use App\Match\Domain\ValueObjet\GameId;
 use App\Match\Domain\ValueObjet\KDA;
@@ -38,7 +39,7 @@ final class ListMatchesHandlerTest extends TestCase
             championId: 157,
             win: true,
             kda: new KDA(10, 5, 15),
-            items: []
+            stats: ParticipantStats::empty(),
         );
 
         return new Matche(

--- a/tests/Unit/Match/Application/UseCase/GetMatchDetailsUseCaseTest.php
+++ b/tests/Unit/Match/Application/UseCase/GetMatchDetailsUseCaseTest.php
@@ -8,6 +8,7 @@ use App\Match\Application\Query\GetMatchByIdQuery;
 use App\Match\Application\UseCase\GetMatchDetailsUseCase;
 use App\Match\Domain\Model\Matche;
 use App\Match\Domain\Model\Participant;
+use App\Match\Domain\Model\ParticipantStats;
 use App\Match\Domain\ValueObjet\GameId;
 use App\Match\Domain\ValueObjet\KDA;
 use App\Match\Domain\ValueObjet\MatchId;
@@ -35,7 +36,7 @@ final class GetMatchDetailsUseCaseTest extends TestCase
             championId: 157,
             win: true,
             kda: new KDA(10, 5, 15),
-            items: ['item1', 'item2']
+            stats: ParticipantStats::empty(),
         );
 
         return new Matche(

--- a/tests/Unit/Match/Domain/Model/MatcheTest.php
+++ b/tests/Unit/Match/Domain/Model/MatcheTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Match\Domain\Model;
 
 use App\Match\Domain\Model\Matche;
 use App\Match\Domain\Model\Participant;
+use App\Match\Domain\Model\ParticipantStats;
 use App\Match\Domain\ValueObjet\GameId;
 use App\Match\Domain\ValueObjet\KDA;
 use App\Match\Domain\ValueObjet\MatchId;
@@ -23,7 +24,7 @@ final class MatcheTest extends TestCase
             championId: $championId,
             win: true,
             kda: new KDA(10, 5, 15),
-            items: ['item1', 'item2']
+            stats: ParticipantStats::empty(),
         );
     }
 

--- a/tests/Unit/Match/Domain/Model/ParticipantTest.php
+++ b/tests/Unit/Match/Domain/Model/ParticipantTest.php
@@ -5,17 +5,39 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Match\Domain\Model;
 
 use App\Match\Domain\Model\Participant;
+use App\Match\Domain\Model\ParticipantStats;
 use App\Match\Domain\ValueObjet\KDA;
 use App\Match\Domain\ValueObjet\SummonerPuuid;
 use PHPUnit\Framework\TestCase;
 
 final class ParticipantTest extends TestCase
 {
+    private function makeStats(array $items = []): ParticipantStats
+    {
+        return new ParticipantStats(
+            cs: 150,
+            goldEarned: 12000,
+            totalDamageDealtToChampions: 45000,
+            totalDamageTaken: 30000,
+            visionScore: 25,
+            lane: 'MIDDLE',
+            individualPosition: 'MIDDLE',
+            summoner1Id: 4,
+            summoner2Id: 14,
+            champLevel: 16,
+            wardsPlaced: 10,
+            wardsKilled: 5,
+            firstBloodKill: false,
+            items: $items,
+        );
+    }
+
     public function testCanCreateParticipant(): void
     {
         $summonerPuuid = SummonerPuuid::fromString('summoner123');
         $kda = new KDA(10, 5, 15);
         $items = ['item1', 'item2', 'item3'];
+        $stats = $this->makeStats($items);
 
         $participant = new Participant(
             summonerPuuid: $summonerPuuid,
@@ -23,7 +45,7 @@ final class ParticipantTest extends TestCase
             championId: 157,
             win: true,
             kda: $kda,
-            items: $items
+            stats: $stats,
         );
 
         $this->assertInstanceOf(Participant::class, $participant);
@@ -32,7 +54,8 @@ final class ParticipantTest extends TestCase
         $this->assertSame(157, $participant->championId());
         $this->assertTrue($participant->win());
         $this->assertSame($kda, $participant->kda());
-        $this->assertSame($items, $participant->items());
+        $this->assertSame($stats, $participant->stats());
+        $this->assertSame($items, $participant->stats()->items());
     }
 
     public function testCanCreateParticipantWithLoss(): void
@@ -46,7 +69,7 @@ final class ParticipantTest extends TestCase
             championId: 64,
             win: false,
             kda: $kda,
-            items: []
+            stats: $this->makeStats(),
         );
 
         $this->assertFalse($participant->win());
@@ -63,10 +86,10 @@ final class ParticipantTest extends TestCase
             championId: 1,
             win: true,
             kda: $kda,
-            items: []
+            stats: $this->makeStats([]),
         );
 
-        $this->assertSame([], $participant->items());
+        $this->assertSame([], $participant->stats()->items());
     }
 
     public function testCannotCreateParticipantWithZeroChampionId(): void
@@ -80,7 +103,7 @@ final class ParticipantTest extends TestCase
             championId: 0,
             win: true,
             kda: new KDA(10, 5, 15),
-            items: []
+            stats: $this->makeStats(),
         );
     }
 
@@ -95,7 +118,7 @@ final class ParticipantTest extends TestCase
             championId: -1,
             win: true,
             kda: new KDA(10, 5, 15),
-            items: []
+            stats: $this->makeStats(),
         );
     }
 
@@ -108,7 +131,7 @@ final class ParticipantTest extends TestCase
             championId: 157,
             win: true,
             kda: new KDA(10, 5, 15),
-            items: []
+            stats: $this->makeStats(),
         );
 
         $retrievedSummonerPuuid = $participant->summonerPuuid();
@@ -124,7 +147,7 @@ final class ParticipantTest extends TestCase
             championId: 157,
             win: true,
             kda: $kda,
-            items: []
+            stats: $this->makeStats(),
         );
 
         $retrievedKda = $participant->kda();


### PR DESCRIPTION
 Introduit un value object `ParticipantStats` regroupant toutes les statistiques détaillées d'un participant (CS, gold, dégâts, vision,sorts d'invocateur, items, etc.) et son entité Doctrine associée `ParticipantStatsEntity` en relation OneToOne.

  - Extrait `items` de `Participant` vers `ParticipantStats`
  - Ajoute cs, goldEarned, damages, visionScore, lane, champLevel, wardsPlaced/Killed, firstBloodKill, summoner spells

  - Met à jour `ParticipantReadModel` pour exposer toutes ces stats
  - Adapte `MatcheFactory` pour construire `ParticipantStats` depuis l'API
  - Ajoute `ParticipantStats::empty()` pour la rétrocompatibilité Doctrine
  - Met à jour les vues MatchDetail (front + admin) et les types partagés
  - Corrige et enrichit les tests unitaires associés