### PR TITLE
feat(admin): onglets, recherche debouncée et tri des colonnes

### DIFF
--- a/assets/admin/components/molecules/GameDataTabItem.vue
+++ b/assets/admin/components/molecules/GameDataTabItem.vue
@@ -3,28 +3,14 @@ defineProps<{
   label: string
   count: number
   active: boolean
-  syncing: boolean
-  disabled: boolean
 }>()
 
-const emit = defineEmits<{
-  select: []
-  sync: []
-}>()
+const emit = defineEmits<{ select: [] }>()
 </script>
 
 <template>
-  <div class="inline-flex items-center gap-1">
-    <button
-      class="btn ml-2"
-      :class="active ? 'btn-primary' : 'btn-secondary'"
-      @click="emit('select')"
-    >
-      {{ label }} ({{ count }})
-    </button>
-    <button class="btn" :disabled="disabled" @click="emit('sync')">
-      <span v-if="syncing" class="spinner"></span>
-      {{ syncing ? '...' : 'Sync' }}
-    </button>
+  <div class="tab-item" :class="{ 'tab-item--active': active }" @click="emit('select')">
+    {{ label }}
+    <span class="text-xs opacity-60 ml-1">({{ count }})</span>
   </div>
 </template>

--- a/assets/admin/components/organisms/AdminSidebar.vue
+++ b/assets/admin/components/organisms/AdminSidebar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { RouterLink, useRouter } from 'vue-router'
+import { LayoutDashboard, Swords, Users, Database, LogOut } from 'lucide-vue-next'
 import { useAuthStore } from '@admin/stores/auth'
 
 const router = useRouter()
@@ -22,36 +23,40 @@ function logout() {
         <li>
           <RouterLink
             to="/"
-            class="block py-3 px-4 text-lol-text no-underline rounded mb-1 transition-colors hover:bg-lol-bg hover:text-lol-gold"
+            class="flex items-center gap-3 py-3 px-4 text-lol-text no-underline rounded mb-1 transition-colors hover:bg-lol-bg hover:text-lol-gold"
             active-class="!bg-lol-bg !text-lol-gold"
           >
+            <LayoutDashboard class="w-4 h-4 shrink-0" />
             Dashboard
           </RouterLink>
         </li>
         <li>
           <RouterLink
             to="/matches"
-            class="block py-3 px-4 text-lol-text no-underline rounded mb-1 transition-colors hover:bg-lol-bg hover:text-lol-gold"
+            class="flex items-center gap-3 py-3 px-4 text-lol-text no-underline rounded mb-1 transition-colors hover:bg-lol-bg hover:text-lol-gold"
             active-class="!bg-lol-bg !text-lol-gold"
           >
+            <Swords class="w-4 h-4 shrink-0" />
             Matches
           </RouterLink>
         </li>
         <li>
           <RouterLink
             to="/summoners"
-            class="block py-3 px-4 text-lol-text no-underline rounded mb-1 transition-colors hover:bg-lol-bg hover:text-lol-gold"
+            class="flex items-center gap-3 py-3 px-4 text-lol-text no-underline rounded mb-1 transition-colors hover:bg-lol-bg hover:text-lol-gold"
             active-class="!bg-lol-bg !text-lol-gold"
           >
+            <Users class="w-4 h-4 shrink-0" />
             Summoners
           </RouterLink>
         </li>
         <li>
           <RouterLink
             to="/game-data"
-            class="block py-3 px-4 text-lol-text no-underline rounded mb-1 transition-colors hover:bg-lol-bg hover:text-lol-gold"
+            class="flex items-center gap-3 py-3 px-4 text-lol-text no-underline rounded mb-1 transition-colors hover:bg-lol-bg hover:text-lol-gold"
             active-class="!bg-lol-bg !text-lol-gold"
           >
+            <Database class="w-4 h-4 shrink-0" />
             Game Data
           </RouterLink>
         </li>
@@ -59,9 +64,10 @@ function logout() {
     </nav>
     <div class="border-t border-lol-border pt-4">
       <button
-        class="w-full py-3 px-4 text-left text-lol-text rounded transition-colors hover:bg-lol-bg hover:text-red-400"
+        class="w-full flex items-center gap-3 py-3 px-4 text-left text-lol-text rounded transition-colors hover:bg-lol-bg hover:text-red-400"
         @click="logout"
       >
+        <LogOut class="w-4 h-4 shrink-0" />
         Logout
       </button>
     </div>

--- a/assets/admin/views/GameData.vue
+++ b/assets/admin/views/GameData.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { gameDataApi } from '@shared/api/gameDataApi'
 import type { Queue, GameMap, GameMode, GameType, Version } from '@shared/types'
+import { useTableControls } from '@shared/composables/useTableControls'
 import AlertMessage from '@shared/components/AlertMessage.vue'
 import SpinnerButton from '@shared/components/SpinnerButton.vue'
+import SortableHeader from '@shared/components/SortableHeader.vue'
 import GameDataTabItem from '@admin/components/molecules/GameDataTabItem.vue'
 import AdminPageTemplate from '@admin/components/templates/AdminPageTemplate.vue'
 
@@ -19,6 +21,20 @@ const activeTab = ref('queues')
 const syncingAll = ref(false)
 const syncingType = ref<string | null>(null)
 const syncMessage = ref<{ type: 'success' | 'error'; text: string } | null>(null)
+
+const queuesCtrl = useTableControls(() => queues.value)
+const mapsCtrl = useTableControls(() => maps.value)
+const modesCtrl = useTableControls(() => gameModes.value)
+const typesCtrl = useTableControls(() => gameTypes.value)
+const versionsCtrl = useTableControls(() => versions.value)
+
+const tabDefs = computed(() => [
+  { key: 'queues', label: 'Queues', count: queues.value.length },
+  { key: 'maps', label: 'Maps', count: maps.value.length },
+  { key: 'modes', label: 'Game Modes', count: gameModes.value.length },
+  { key: 'types', label: 'Game Types', count: gameTypes.value.length },
+  { key: 'versions', label: 'Versions', count: versions.value.length },
+])
 
 async function loadAllData() {
   const [queuesRes, mapsRes, modesRes, typesRes, versionsRes] = await Promise.all([
@@ -125,142 +141,261 @@ onMounted(async () => {
 
     <div v-if="loading" class="loading">Loading...</div>
     <div v-else-if="error" class="error">{{ error }}</div>
-    <div v-else>
-      <div class="mb-4">
-        <div class="flex flex-wrap gap-1">
-          <GameDataTabItem
-            label="Queues"
-            :count="queues.length"
-            :active="activeTab === 'queues'"
-            :syncing="syncingType === 'queues'"
-            :disabled="isSyncing('queues')"
-            @select="activeTab = 'queues'"
-            @sync="syncType('queues')"
-          />
-          <GameDataTabItem
-            label="Maps"
-            :count="maps.length"
-            :active="activeTab === 'maps'"
-            :syncing="syncingType === 'maps'"
-            :disabled="isSyncing('maps')"
-            @select="activeTab = 'maps'"
-            @sync="syncType('maps')"
-          />
-          <GameDataTabItem
-            label="Game Modes"
-            :count="gameModes.length"
-            :active="activeTab === 'modes'"
-            :syncing="syncingType === 'game-modes'"
-            :disabled="isSyncing('game-modes')"
-            @select="activeTab = 'modes'"
-            @sync="syncType('game-modes')"
-          />
-          <GameDataTabItem
-            label="Game Types"
-            :count="gameTypes.length"
-            :active="activeTab === 'types'"
-            :syncing="syncingType === 'game-types'"
-            :disabled="isSyncing('game-types')"
-            @select="activeTab = 'types'"
-            @sync="syncType('game-types')"
-          />
-          <GameDataTabItem
-            label="Version"
-            :count="versions.length"
-            :active="activeTab === 'versions'"
-            :syncing="syncingType === 'versions'"
-            :disabled="isSyncing('versions')"
-            @select="activeTab = 'versions'"
-            @sync="syncType('versions')"
-          />
+    <div v-else class="bg-lol-card rounded-lg border border-lol-border mb-6">
+      <div class="tab-bar px-2">
+        <GameDataTabItem
+          v-for="tab in tabDefs"
+          :key="tab.key"
+          :label="tab.label"
+          :count="tab.count"
+          :active="activeTab === tab.key"
+          @select="activeTab = tab.key"
+        />
+      </div>
+
+      <div class="p-6">
+        <!-- Queues -->
+        <div v-if="activeTab === 'queues'">
+          <div class="flex items-center gap-3 mb-4">
+            <input
+              v-model="queuesCtrl.search"
+              class="table-search flex-1"
+              placeholder="Rechercher dans les queues..."
+            />
+            <SpinnerButton
+              :loading="syncingType === 'queues'"
+              :disabled="isSyncing('queues')"
+              label="Sync"
+              loading-label="Syncing..."
+              @click="syncType('queues')"
+            />
+          </div>
+          <table class="table">
+            <thead>
+              <tr>
+                <SortableHeader
+                  label="Queue ID"
+                  sort-key="queueId"
+                  :active-sort-key="queuesCtrl.sortKey"
+                  :sort-dir="queuesCtrl.sortDir"
+                  @sort="queuesCtrl.toggleSort"
+                />
+                <SortableHeader
+                  label="Map"
+                  sort-key="map"
+                  :active-sort-key="queuesCtrl.sortKey"
+                  :sort-dir="queuesCtrl.sortDir"
+                  @sort="queuesCtrl.toggleSort"
+                />
+                <SortableHeader
+                  label="Description"
+                  sort-key="description"
+                  :active-sort-key="queuesCtrl.sortKey"
+                  :sort-dir="queuesCtrl.sortDir"
+                  @sort="queuesCtrl.toggleSort"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="queue in queuesCtrl.rows" :key="(queue as Queue).queueId">
+                <td>{{ (queue as Queue).queueId }}</td>
+                <td>{{ (queue as Queue).map }}</td>
+                <td>{{ (queue as Queue).description || '-' }}</td>
+              </tr>
+              <tr v-if="queuesCtrl.rows.length === 0">
+                <td colspan="3" class="text-center text-lol-muted">Aucun résultat</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
-      </div>
 
-      <div v-if="activeTab === 'queues'" class="card">
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Queue ID</th>
-              <th>Map</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="queue in queues" :key="queue.queueId">
-              <td>{{ queue.queueId }}</td>
-              <td>{{ queue.map }}</td>
-              <td>{{ queue.description || '-' }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+        <!-- Maps -->
+        <div v-if="activeTab === 'maps'">
+          <div class="flex items-center gap-3 mb-4">
+            <input
+              v-model="mapsCtrl.search"
+              class="table-search flex-1"
+              placeholder="Rechercher dans les maps..."
+            />
+            <SpinnerButton
+              :loading="syncingType === 'maps'"
+              :disabled="isSyncing('maps')"
+              label="Sync"
+              loading-label="Syncing..."
+              @click="syncType('maps')"
+            />
+          </div>
+          <table class="table">
+            <thead>
+              <tr>
+                <SortableHeader
+                  label="Map ID"
+                  sort-key="mapId"
+                  :active-sort-key="mapsCtrl.sortKey"
+                  :sort-dir="mapsCtrl.sortDir"
+                  @sort="mapsCtrl.toggleSort"
+                />
+                <SortableHeader
+                  label="Map Name"
+                  sort-key="mapName"
+                  :active-sort-key="mapsCtrl.sortKey"
+                  :sort-dir="mapsCtrl.sortDir"
+                  @sort="mapsCtrl.toggleSort"
+                />
+                <SortableHeader
+                  label="Notes"
+                  sort-key="notes"
+                  :active-sort-key="mapsCtrl.sortKey"
+                  :sort-dir="mapsCtrl.sortDir"
+                  @sort="mapsCtrl.toggleSort"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="map in mapsCtrl.rows" :key="(map as GameMap).mapId">
+                <td>{{ (map as GameMap).mapId }}</td>
+                <td>{{ (map as GameMap).mapName }}</td>
+                <td>{{ (map as GameMap).notes || '-' }}</td>
+              </tr>
+              <tr v-if="mapsCtrl.rows.length === 0">
+                <td colspan="3" class="text-center text-lol-muted">Aucun résultat</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
 
-      <div v-if="activeTab === 'maps'" class="card">
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Map ID</th>
-              <th>Map Name</th>
-              <th>Notes</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="map in maps" :key="map.mapId">
-              <td>{{ map.mapId }}</td>
-              <td>{{ map.mapName }}</td>
-              <td>{{ map.notes || '-' }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+        <!-- Game Modes -->
+        <div v-if="activeTab === 'modes'">
+          <div class="flex items-center gap-3 mb-4">
+            <input
+              v-model="modesCtrl.search"
+              class="table-search flex-1"
+              placeholder="Rechercher dans les modes..."
+            />
+            <SpinnerButton
+              :loading="syncingType === 'game-modes'"
+              :disabled="isSyncing('game-modes')"
+              label="Sync"
+              loading-label="Syncing..."
+              @click="syncType('game-modes')"
+            />
+          </div>
+          <table class="table">
+            <thead>
+              <tr>
+                <SortableHeader
+                  label="Game Mode"
+                  sort-key="gameMode"
+                  :active-sort-key="modesCtrl.sortKey"
+                  :sort-dir="modesCtrl.sortDir"
+                  @sort="modesCtrl.toggleSort"
+                />
+                <SortableHeader
+                  label="Description"
+                  sort-key="description"
+                  :active-sort-key="modesCtrl.sortKey"
+                  :sort-dir="modesCtrl.sortDir"
+                  @sort="modesCtrl.toggleSort"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="mode in modesCtrl.rows" :key="(mode as GameMode).gameMode">
+                <td>{{ (mode as GameMode).gameMode }}</td>
+                <td>{{ (mode as GameMode).description }}</td>
+              </tr>
+              <tr v-if="modesCtrl.rows.length === 0">
+                <td colspan="2" class="text-center text-lol-muted">Aucun résultat</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
 
-      <div v-if="activeTab === 'modes'" class="card">
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Game Mode</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="mode in gameModes" :key="mode.gameMode">
-              <td>{{ mode.gameMode }}</td>
-              <td>{{ mode.description }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+        <!-- Game Types -->
+        <div v-if="activeTab === 'types'">
+          <div class="flex items-center gap-3 mb-4">
+            <input
+              v-model="typesCtrl.search"
+              class="table-search flex-1"
+              placeholder="Rechercher dans les types..."
+            />
+            <SpinnerButton
+              :loading="syncingType === 'game-types'"
+              :disabled="isSyncing('game-types')"
+              label="Sync"
+              loading-label="Syncing..."
+              @click="syncType('game-types')"
+            />
+          </div>
+          <table class="table">
+            <thead>
+              <tr>
+                <SortableHeader
+                  label="Game Type"
+                  sort-key="gameType"
+                  :active-sort-key="typesCtrl.sortKey"
+                  :sort-dir="typesCtrl.sortDir"
+                  @sort="typesCtrl.toggleSort"
+                />
+                <SortableHeader
+                  label="Description"
+                  sort-key="description"
+                  :active-sort-key="typesCtrl.sortKey"
+                  :sort-dir="typesCtrl.sortDir"
+                  @sort="typesCtrl.toggleSort"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="type in typesCtrl.rows" :key="(type as GameType).gameType">
+                <td>{{ (type as GameType).gameType }}</td>
+                <td>{{ (type as GameType).description }}</td>
+              </tr>
+              <tr v-if="typesCtrl.rows.length === 0">
+                <td colspan="2" class="text-center text-lol-muted">Aucun résultat</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
 
-      <div v-if="activeTab === 'types'" class="card">
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Game Type</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="type in gameTypes" :key="type.gameType">
-              <td>{{ type.gameType }}</td>
-              <td>{{ type.description }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div v-if="activeTab === 'versions'" class="card">
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Version</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="version in versions" :key="version.version">
-              <td>{{ version.version }}</td>
-            </tr>
-          </tbody>
-        </table>
+        <!-- Versions -->
+        <div v-if="activeTab === 'versions'">
+          <div class="flex items-center gap-3 mb-4">
+            <input
+              v-model="versionsCtrl.search"
+              class="table-search flex-1"
+              placeholder="Rechercher une version..."
+            />
+            <SpinnerButton
+              :loading="syncingType === 'versions'"
+              :disabled="isSyncing('versions')"
+              label="Sync"
+              loading-label="Syncing..."
+              @click="syncType('versions')"
+            />
+          </div>
+          <table class="table">
+            <thead>
+              <tr>
+                <SortableHeader
+                  label="Version"
+                  sort-key="version"
+                  :active-sort-key="versionsCtrl.sortKey"
+                  :sort-dir="versionsCtrl.sortDir"
+                  @sort="versionsCtrl.toggleSort"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="version in versionsCtrl.rows" :key="(version as Version).version">
+                <td>{{ (version as Version).version }}</td>
+              </tr>
+              <tr v-if="versionsCtrl.rows.length === 0">
+                <td colspan="1" class="text-center text-lol-muted">Aucun résultat</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </AdminPageTemplate>

--- a/assets/admin/views/MatchList.vue
+++ b/assets/admin/views/MatchList.vue
@@ -4,7 +4,9 @@ import { RouterLink } from 'vue-router'
 import { api } from '@shared/api/client'
 import type { Match } from '@shared/types'
 import { usePagination } from '@shared/composables/usePagination'
+import { useTableControls } from '@shared/composables/useTableControls'
 import PaginationBar from '@shared/components/PaginationBar.vue'
+import SortableHeader from '@shared/components/SortableHeader.vue'
 import AdminPageTemplate from '@admin/components/templates/AdminPageTemplate.vue'
 
 const {
@@ -20,6 +22,8 @@ const {
   nextPage,
   previousPage,
 } = usePagination<Match>((page, limit) => api.getMatches(page, limit))
+
+const ctrl = useTableControls(() => matches.value)
 
 onMounted(() => fetchPage(1))
 
@@ -43,6 +47,14 @@ function formatDate(dateString: string): string {
     <div v-if="initialLoading" class="loading">Loading...</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else class="card">
+      <div class="mb-4">
+        <input
+          v-model="ctrl.search"
+          class="table-search"
+          placeholder="Rechercher dans la page courante..."
+        />
+      </div>
+
       <div
         class="transition-opacity duration-200"
         :class="{ 'opacity-50 pointer-events-none': loading }"
@@ -50,31 +62,75 @@ function formatDate(dateString: string): string {
         <table class="table">
           <thead>
             <tr>
-              <th>Match ID</th>
-              <th>Version</th>
-              <th>Played At</th>
-              <th>Duration</th>
-              <th>Mode</th>
-              <th>Platform</th>
-              <th>Players</th>
+              <SortableHeader
+                label="Match ID"
+                sort-key="id"
+                :active-sort-key="ctrl.sortKey"
+                :sort-dir="ctrl.sortDir"
+                @sort="ctrl.toggleSort"
+              />
+              <SortableHeader
+                label="Version"
+                sort-key="version"
+                :active-sort-key="ctrl.sortKey"
+                :sort-dir="ctrl.sortDir"
+                @sort="ctrl.toggleSort"
+              />
+              <SortableHeader
+                label="Played At"
+                sort-key="playedAt"
+                :active-sort-key="ctrl.sortKey"
+                :sort-dir="ctrl.sortDir"
+                @sort="ctrl.toggleSort"
+              />
+              <SortableHeader
+                label="Duration"
+                sort-key="durationSeconds"
+                :active-sort-key="ctrl.sortKey"
+                :sort-dir="ctrl.sortDir"
+                @sort="ctrl.toggleSort"
+              />
+              <SortableHeader
+                label="Mode"
+                sort-key="gameMode"
+                :active-sort-key="ctrl.sortKey"
+                :sort-dir="ctrl.sortDir"
+                @sort="ctrl.toggleSort"
+              />
+              <SortableHeader
+                label="Platform"
+                sort-key="platform"
+                :active-sort-key="ctrl.sortKey"
+                :sort-dir="ctrl.sortDir"
+                @sort="ctrl.toggleSort"
+              />
+              <SortableHeader
+                label="Players"
+                sort-key="participantsCount"
+                :active-sort-key="ctrl.sortKey"
+                :sort-dir="ctrl.sortDir"
+                @sort="ctrl.toggleSort"
+              />
               <th>Actions</th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="match in matches" :key="match.id">
-              <td>{{ match.id }}</td>
-              <td>{{ match.version }}</td>
-              <td>{{ formatDate(match.playedAt) }}</td>
-              <td>{{ match.durationFormatted }}</td>
-              <td>{{ match.gameMode }}</td>
-              <td>{{ match.platform }}</td>
-              <td>{{ match.participantsCount }}</td>
+            <tr v-for="match in ctrl.rows" :key="(match as Match).id">
+              <td>{{ (match as Match).id }}</td>
+              <td>{{ (match as Match).version }}</td>
+              <td>{{ formatDate((match as Match).playedAt) }}</td>
+              <td>{{ (match as Match).durationFormatted }}</td>
+              <td>{{ (match as Match).gameMode }}</td>
+              <td>{{ (match as Match).platform }}</td>
+              <td>{{ (match as Match).participantsCount }}</td>
               <td>
-                <RouterLink :to="`/matches/${match.id}`" class="btn btn-primary">View</RouterLink>
+                <RouterLink :to="`/matches/${(match as Match).id}`" class="btn btn-primary"
+                  >View</RouterLink
+                >
               </td>
             </tr>
-            <tr v-if="matches.length === 0">
-              <td colspan="8" class="text-center">No matches found</td>
+            <tr v-if="ctrl.rows.length === 0">
+              <td colspan="8" class="text-center text-lol-muted">Aucun résultat</td>
             </tr>
           </tbody>
         </table>

--- a/assets/shared/components/SortableHeader.vue
+++ b/assets/shared/components/SortableHeader.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import type { SortDir } from '@shared/composables/useTableControls'
+import { ChevronsUpDown, ChevronUp, ChevronDown } from 'lucide-vue-next'
+
+defineProps<{
+  label: string
+  sortKey: string
+  activeSortKey: string | null
+  sortDir: SortDir
+}>()
+
+const emit = defineEmits<{ sort: [key: string] }>()
+</script>
+
+<template>
+  <th class="sortable-th" @click="emit('sort', sortKey)">
+    <span class="flex items-center gap-1">
+      {{ label }}
+      <ChevronUp
+        v-if="activeSortKey === sortKey && sortDir === 'asc'"
+        class="w-3 h-3 text-lol-gold shrink-0"
+      />
+      <ChevronDown
+        v-else-if="activeSortKey === sortKey && sortDir === 'desc'"
+        class="w-3 h-3 text-lol-gold shrink-0"
+      />
+      <ChevronsUpDown v-else class="w-3 h-3 opacity-30 shrink-0" />
+    </span>
+  </th>
+</template>

--- a/assets/shared/components/SpinnerButton.vue
+++ b/assets/shared/components/SpinnerButton.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { Loader2 } from 'lucide-vue-next'
+
 defineProps<{
   loading: boolean
   label: string
@@ -9,7 +11,7 @@ defineProps<{
 
 <template>
   <button class="btn btn-primary" :disabled="loading || disabled" v-bind="$attrs">
-    <span v-if="loading" class="spinner"></span>
+    <Loader2 v-if="loading" class="inline w-4 h-4 mr-1 animate-spin" />
     {{ loading ? (loadingLabel ?? label) : label }}
   </button>
 </template>

--- a/assets/shared/composables/useTableControls.ts
+++ b/assets/shared/composables/useTableControls.ts
@@ -1,0 +1,55 @@
+import { ref, computed, reactive } from 'vue'
+import { useDebounce } from '@vueuse/core'
+
+export type SortDir = 'asc' | 'desc' | null
+
+export function useTableControls<T>(source: () => T[], debounceMs = 300) {
+  const search = ref('')
+  const debouncedSearch = useDebounce(search, debounceMs)
+  const sortKey = ref<string | null>(null)
+  const sortDir = ref<SortDir>(null)
+
+  function toggleSort(key: string) {
+    if (sortKey.value === key) {
+      if (sortDir.value === 'asc') {
+        sortDir.value = 'desc'
+      } else {
+        sortKey.value = null
+        sortDir.value = null
+      }
+    } else {
+      sortKey.value = key
+      sortDir.value = 'asc'
+    }
+  }
+
+  const rows = computed(() => {
+    const q = debouncedSearch.value.toLowerCase().trim()
+    let result: T[] = source()
+
+    if (q) {
+      result = result.filter((item) =>
+        Object.values(item as Record<string, unknown>).some((v) =>
+          String(v ?? '')
+            .toLowerCase()
+            .includes(q),
+        ),
+      )
+    }
+
+    if (sortKey.value && sortDir.value) {
+      const key = sortKey.value
+      const dir = sortDir.value
+      result = [...result].sort((a, b) => {
+        const av = (a as Record<string, unknown>)[key] ?? ''
+        const bv = (b as Record<string, unknown>)[key] ?? ''
+        const cmp = String(av).localeCompare(String(bv), undefined, { numeric: true })
+        return dir === 'asc' ? cmp : -cmp
+      })
+    }
+
+    return result
+  })
+
+  return reactive({ search, sortKey, sortDir, toggleSort, rows })
+}

--- a/assets/shared/tailwind.css
+++ b/assets/shared/tailwind.css
@@ -27,17 +27,6 @@
 }
 
 @layer components {
-  @keyframes spin {
-    to {
-      transform: rotate(360deg);
-    }
-  }
-
-  .spinner {
-    @apply inline-block w-3 h-3 border-2 border-current border-r-transparent rounded-full mr-1;
-    animation: spin 0.6s linear infinite;
-  }
-
   .container {
     @apply max-w-[1200px] mx-auto px-4;
   }
@@ -121,5 +110,25 @@
 
   .search-input {
     @apply w-full p-4 text-base border-2 border-lol-gold rounded-lg bg-lol-card text-lol-text placeholder:text-lol-muted focus:outline-none focus:ring-3 focus:ring-lol-gold/30;
+  }
+
+  .tab-bar {
+    @apply flex border-b border-lol-border;
+  }
+
+  .tab-item {
+    @apply px-5 py-3 text-sm font-medium cursor-pointer text-lol-muted border-b-2 border-transparent -mb-px transition-colors hover:text-lol-text;
+  }
+
+  .tab-item--active {
+    @apply text-lol-gold border-lol-gold;
+  }
+
+  .sortable-th {
+    @apply cursor-pointer select-none hover:text-lol-text;
+  }
+
+  .table-search {
+    @apply w-full px-3 py-2 text-sm border border-lol-border rounded bg-lol-bg text-lol-text placeholder:text-lol-muted focus:outline-none focus:border-lol-gold;
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.0",
+    "@vueuse/core": "^14.2.1",
     "chart.js": "^4.5.1",
+    "lucide-vue-next": "^0.577.0",
     "ofetch": "^1.5.1",
     "pinia": "^2.1.0",
     "tailwindcss": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,6 +568,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/web-bluetooth@^0.0.21":
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz#525433c784aed9b457aaa0ee3d92aeb71f346b63"
+  integrity sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==
+
 "@typescript-eslint/eslint-plugin@8.56.1":
   version "8.56.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz#b1ce606d87221daec571e293009675992f0aae76"
@@ -787,6 +792,25 @@
   version "3.5.28"
   resolved "https://registry.npmjs.org/@vue/shared/-/shared-3.5.28.tgz"
   integrity sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==
+
+"@vueuse/core@^14.2.1":
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-14.2.1.tgz#b5cf36a07b4ea973381e18523ad0ed6ddc98a5be"
+  integrity sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==
+  dependencies:
+    "@types/web-bluetooth" "^0.0.21"
+    "@vueuse/metadata" "14.2.1"
+    "@vueuse/shared" "14.2.1"
+
+"@vueuse/metadata@14.2.1":
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-14.2.1.tgz#bd3338a565c2f651b9d18ac0f8825aa6077ee461"
+  integrity sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==
+
+"@vueuse/shared@14.2.1":
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-14.2.1.tgz#829a271147937f6b105bb1422d3171e6142f47ba"
+  integrity sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -1319,6 +1343,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lucide-vue-next@^0.577.0:
+  version "0.577.0"
+  resolved "https://registry.yarnpkg.com/lucide-vue-next/-/lucide-vue-next-0.577.0.tgz#840cbc25e748dd69b6abd4133b8c52f8c7fbc052"
+  integrity sha512-py05bAfv9SHVJqscbiOnjcnLlEmOffA58a+7XhZuFxrs6txe1E8VoR1ngWGTYO+9aVKABAz8l3ee3PqiQN9QPA==
 
 magic-string@^0.30.21:
   version "0.30.21"


### PR DESCRIPTION
- useTableControls : recherche debouncée via @vueuse/core + tri asc/desc/reset
- SortableHeader : atom avec icônes Lucide (ChevronUp/Down/ChevronsUpDown)
- GameDataTabItem : refactorisé en onglet pur, bouton sync déplacé dans le contenu
- GameData : tab-bar intégrée dans la card, recherche et tri par tableau
- MatchList : recherche sur la page courante, colonnes triables
- AdminSidebar : icônes Lucide sur les liens de navigation et logout
- SpinnerButton : Loader2 animate-spin remplace le spinner CSS custom
- Installation de lucide-vue-next et @vueuse/core