### PR TITLE
feat(admin): add server-side filters on match list (platform, game mode, version, date)

### DIFF
--- a/assets/admin/views/MatchList.vue
+++ b/assets/admin/views/MatchList.vue
@@ -1,13 +1,38 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { RouterLink } from 'vue-router'
+import { matchApi } from '@shared/api/matchApi'
 import { api } from '@shared/api/client'
-import type { Match } from '@shared/types'
+import type { Match, Platform, GameMode, Version } from '@shared/types'
+import type { MatchFilters } from '@shared/api/matchApi'
 import { usePagination } from '@shared/composables/usePagination'
 import { useTableControls } from '@shared/composables/useTableControls'
 import PaginationBar from '@shared/components/PaginationBar.vue'
 import SortableHeader from '@shared/components/SortableHeader.vue'
 import AdminPageTemplate from '@admin/components/templates/AdminPageTemplate.vue'
+
+const platforms = ref<Platform[]>([])
+const gameModes = ref<GameMode[]>([])
+const versions = ref<Version[]>([])
+
+const filters = ref<MatchFilters>({
+  platform: '',
+  gameMode: '',
+  version: '',
+  dateFrom: '',
+  dateTo: '',
+})
+
+function activeFilters(): MatchFilters {
+  const f = filters.value
+  return {
+    platform: f.platform || undefined,
+    gameMode: f.gameMode || undefined,
+    version: f.version || undefined,
+    dateFrom: f.dateFrom || undefined,
+    dateTo: f.dateTo || undefined,
+  }
+}
 
 const {
   items: matches,
@@ -21,11 +46,30 @@ const {
   goToPage,
   nextPage,
   previousPage,
-} = usePagination<Match>((page, limit) => api.getMatches(page, limit))
+} = usePagination<Match>((page, limit) => matchApi.getMatches(page, limit, activeFilters()))
 
 const ctrl = useTableControls(() => matches.value)
 
-onMounted(() => fetchPage(1))
+onMounted(async () => {
+  const [platformsRes, gameModesRes, versionsRes] = await Promise.all([
+    api.getPlatforms(),
+    api.getGameModes(),
+    api.getVersions(),
+  ])
+  platforms.value = platformsRes.data
+  gameModes.value = gameModesRes.data
+  versions.value = versionsRes.data
+
+  await fetchPage(1)
+})
+
+watch(filters, () => fetchPage(1), { deep: true })
+
+function resetFilters() {
+  filters.value = { platform: '', gameMode: '', version: '', dateFrom: '', dateTo: '' }
+}
+
+const hasActiveFilters = () => Object.values(filters.value).some((v) => v !== '')
 
 function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleDateString('fr-FR', {
@@ -47,12 +91,46 @@ function formatDate(dateString: string): string {
     <div v-if="initialLoading" class="loading">Loading...</div>
     <div v-else-if="error" class="error">{{ error }}</div>
     <div v-else class="card">
-      <div class="mb-4">
+      <div class="mb-4 flex flex-wrap gap-2 items-end">
         <input
           v-model="ctrl.search"
           class="table-search"
           placeholder="Rechercher dans la page courante..."
         />
+
+        <select v-model="filters.platform" class="table-filter-select">
+          <option value="">Toutes les plateformes</option>
+          <option v-for="p in platforms" :key="p.value" :value="p.value">{{ p.label }}</option>
+        </select>
+
+        <select v-model="filters.gameMode" class="table-filter-select">
+          <option value="">Tous les modes</option>
+          <option v-for="m in gameModes" :key="m.gameMode" :value="m.gameMode">
+            {{ m.gameMode }}
+          </option>
+        </select>
+
+        <select v-model="filters.version" class="table-filter-select">
+          <option value="">Toutes les versions</option>
+          <option v-for="v in versions" :key="v.version" :value="v.version">
+            {{ v.version }}
+          </option>
+        </select>
+
+        <div class="flex items-center gap-1">
+          <input
+            v-model="filters.dateFrom"
+            type="date"
+            class="table-filter-input"
+            title="Date début"
+          />
+          <span class="text-lol-muted text-sm">→</span>
+          <input v-model="filters.dateTo" type="date" class="table-filter-input" title="Date fin" />
+        </div>
+
+        <button v-if="hasActiveFilters()" class="btn btn-secondary text-sm" @click="resetFilters">
+          Réinitialiser
+        </button>
       </div>
 
       <div

--- a/assets/shared/api/matchApi.ts
+++ b/assets/shared/api/matchApi.ts
@@ -1,9 +1,27 @@
 import type { Match, ApiResponse, PaginatedResponse } from '@shared/types'
 import { fetchApi } from './fetchApi'
 
+export interface MatchFilters {
+  platform?: string
+  gameMode?: string
+  version?: string
+  dateFrom?: string
+  dateTo?: string
+}
+
+function buildMatchesUrl(page: number, limit: number, filters: MatchFilters = {}): string {
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) })
+  if (filters.platform) params.set('platform', filters.platform)
+  if (filters.gameMode) params.set('gameMode', filters.gameMode)
+  if (filters.version) params.set('version', filters.version)
+  if (filters.dateFrom) params.set('dateFrom', filters.dateFrom)
+  if (filters.dateTo) params.set('dateTo', filters.dateTo)
+  return `/matches?${params.toString()}`
+}
+
 export const matchApi = {
-  getMatches: (page = 1, limit = 20) =>
-    fetchApi<PaginatedResponse<Match>>(`/matches?page=${page}&limit=${limit}`),
+  getMatches: (page = 1, limit = 20, filters: MatchFilters = {}) =>
+    fetchApi<PaginatedResponse<Match>>(buildMatchesUrl(page, limit, filters)),
   getMatch: (matchId: string) => fetchApi<ApiResponse<Match>>(`/matches/${matchId}`),
   getMatchesBySummoner: (puuid: string, page = 1, limit = 10) =>
     fetchApi<PaginatedResponse<Match>>(`/matches/summoner/${puuid}?page=${page}&limit=${limit}`),

--- a/assets/shared/tailwind.css
+++ b/assets/shared/tailwind.css
@@ -131,4 +131,12 @@
   .table-search {
     @apply w-full px-3 py-2 text-sm border border-lol-border rounded bg-lol-bg text-lol-text placeholder:text-lol-muted focus:outline-none focus:border-lol-gold;
   }
+
+  .table-filter-select {
+    @apply px-3 py-2 text-sm border border-lol-border rounded bg-lol-bg text-lol-text focus:outline-none focus:border-lol-gold cursor-pointer;
+  }
+
+  .table-filter-input {
+    @apply px-3 py-2 text-sm border border-lol-border rounded bg-lol-bg text-lol-text placeholder:text-lol-muted focus:outline-none focus:border-lol-gold;
+  }
 }

--- a/src/Match/Application/Filter/MatchFilterSpecificationInterface.php
+++ b/src/Match/Application/Filter/MatchFilterSpecificationInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Match\Application\Filter;
+
+use Doctrine\ORM\QueryBuilder;
+
+interface MatchFilterSpecificationInterface
+{
+    public function apply(QueryBuilder $qb): void;
+}

--- a/src/Match/Application/Filter/MatchFilters.php
+++ b/src/Match/Application/Filter/MatchFilters.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Match\Application\Filter;
+
+use Doctrine\ORM\QueryBuilder;
+
+final class MatchFilters
+{
+    /** @var MatchFilterSpecificationInterface[] */
+    private array $specifications;
+
+    public function __construct(MatchFilterSpecificationInterface ...$specifications)
+    {
+        $this->specifications = $specifications;
+    }
+
+    public function apply(QueryBuilder $qb): void
+    {
+        foreach ($this->specifications as $specification) {
+            $specification->apply($qb);
+        }
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->specifications;
+    }
+}

--- a/src/Match/Application/Filter/MatchFiltersFactory.php
+++ b/src/Match/Application/Filter/MatchFiltersFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Match\Application\Filter;
+
+use App\Match\Application\Filter\Specification\DateFromSpecification;
+use App\Match\Application\Filter\Specification\DateToSpecification;
+use App\Match\Application\Filter\Specification\GameModeSpecification;
+use App\Match\Application\Filter\Specification\PlatformSpecification;
+use App\Match\Application\Filter\Specification\VersionSpecification;
+
+final class MatchFiltersFactory
+{
+    public static function fromQueryParams(
+        ?string $platform,
+        ?string $gameMode,
+        ?string $version,
+        ?string $dateFrom,
+        ?string $dateTo,
+    ): MatchFilters {
+        $specifications = [];
+
+        if (null !== $platform) {
+            $specifications[] = new PlatformSpecification($platform);
+        }
+
+        if (null !== $gameMode) {
+            $specifications[] = new GameModeSpecification($gameMode);
+        }
+
+        if (null !== $version) {
+            $specifications[] = new VersionSpecification($version);
+        }
+
+        if (null !== $dateFrom) {
+            $specifications[] = new DateFromSpecification(new \DateTimeImmutable($dateFrom . ' 00:00:00'));
+        }
+
+        if (null !== $dateTo) {
+            $specifications[] = new DateToSpecification(new \DateTimeImmutable($dateTo . ' 23:59:59'));
+        }
+
+        return new MatchFilters(...$specifications);
+    }
+}

--- a/src/Match/Application/Filter/Specification/DateFromSpecification.php
+++ b/src/Match/Application/Filter/Specification/DateFromSpecification.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Match\Application\Filter\Specification;
+
+use App\Match\Application\Filter\MatchFilterSpecificationInterface;
+use Doctrine\ORM\QueryBuilder;
+
+final class DateFromSpecification implements MatchFilterSpecificationInterface
+{
+    public function __construct(private readonly \DateTimeImmutable $dateFrom)
+    {
+    }
+
+    public function apply(QueryBuilder $qb): void
+    {
+        $qb->andWhere('m.playedAt >= :dateFrom')
+            ->setParameter('dateFrom', $this->dateFrom);
+    }
+}

--- a/src/Match/Application/Filter/Specification/DateToSpecification.php
+++ b/src/Match/Application/Filter/Specification/DateToSpecification.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Match\Application\Filter\Specification;
+
+use App\Match\Application\Filter\MatchFilterSpecificationInterface;
+use Doctrine\ORM\QueryBuilder;
+
+final class DateToSpecification implements MatchFilterSpecificationInterface
+{
+    public function __construct(private readonly \DateTimeImmutable $dateTo)
+    {
+    }
+
+    public function apply(QueryBuilder $qb): void
+    {
+        $qb->andWhere('m.playedAt <= :dateTo')
+            ->setParameter('dateTo', $this->dateTo);
+    }
+}

--- a/src/Match/Application/Filter/Specification/GameModeSpecification.php
+++ b/src/Match/Application/Filter/Specification/GameModeSpecification.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Match\Application\Filter\Specification;
+
+use App\Match\Application\Filter\MatchFilterSpecificationInterface;
+use Doctrine\ORM\QueryBuilder;
+
+final class GameModeSpecification implements MatchFilterSpecificationInterface
+{
+    public function __construct(private readonly string $gameMode)
+    {
+    }
+
+    public function apply(QueryBuilder $qb): void
+    {
+        $qb->innerJoin('m.gameMode', 'gm')
+            ->andWhere('gm.gameMode = :gameMode')
+            ->setParameter('gameMode', $this->gameMode);
+    }
+}

--- a/src/Match/Application/Filter/Specification/PlatformSpecification.php
+++ b/src/Match/Application/Filter/Specification/PlatformSpecification.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Match\Application\Filter\Specification;
+
+use App\Match\Application\Filter\MatchFilterSpecificationInterface;
+use Doctrine\ORM\QueryBuilder;
+
+final class PlatformSpecification implements MatchFilterSpecificationInterface
+{
+    public function __construct(private readonly string $platform)
+    {
+    }
+
+    public function apply(QueryBuilder $qb): void
+    {
+        $qb->andWhere('m.platform = :platform')
+            ->setParameter('platform', $this->platform);
+    }
+}

--- a/src/Match/Application/Filter/Specification/VersionSpecification.php
+++ b/src/Match/Application/Filter/Specification/VersionSpecification.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Match\Application\Filter\Specification;
+
+use App\Match\Application\Filter\MatchFilterSpecificationInterface;
+use Doctrine\ORM\QueryBuilder;
+
+final class VersionSpecification implements MatchFilterSpecificationInterface
+{
+    public function __construct(private readonly string $version)
+    {
+    }
+
+    public function apply(QueryBuilder $qb): void
+    {
+        $qb->innerJoin('m.version', 'v')
+            ->andWhere('v.version LIKE :version')
+            ->setParameter('version', $this->version . '%');
+    }
+}

--- a/src/Match/Application/Query/ListMatchesQuery.php
+++ b/src/Match/Application/Query/ListMatchesQuery.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Match\Application\Query;
 
+use App\Match\Application\Filter\MatchFilters;
 use App\SharedContext\Domain\Pagination\PaginationRequest;
 
 final class ListMatchesQuery
 {
     public function __construct(
         public readonly PaginationRequest $pagination = new PaginationRequest(),
+        public readonly MatchFilters $filters = new MatchFilters(),
     ) {
     }
 }

--- a/src/Match/Application/QueryHandler/ListMatchesHandler.php
+++ b/src/Match/Application/QueryHandler/ListMatchesHandler.php
@@ -23,9 +23,15 @@ final class ListMatchesHandler
     public function __invoke(ListMatchesQuery $query): PaginatedResult
     {
         $pagination = $query->pagination;
+        $filters = $query->filters;
 
-        $matches = $this->repository->findPaginated($pagination->offset(), $pagination->limit);
-        $total = $this->repository->count();
+        if ($filters->isEmpty()) {
+            $matches = $this->repository->findPaginated($pagination->offset(), $pagination->limit);
+            $total = $this->repository->count();
+        } else {
+            $matches = $this->repository->findPaginatedWithFilters($pagination->offset(), $pagination->limit, $filters);
+            $total = $this->repository->countWithFilters($filters);
+        }
 
         return new PaginatedResult(
             items: array_map(MatchReadModel::fromDomain(...), $matches),

--- a/src/Match/Domain/Repository/MatchRepositoryInterface.php
+++ b/src/Match/Domain/Repository/MatchRepositoryInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\Match\Domain\Repository;
 
+use App\Match\Application\Filter\MatchFilters;
 use App\Match\Domain\Model\Matche;
 use App\Match\Domain\ValueObjet\MatchId;
 use App\SharedContext\Domain\Repository\PaginatableRepositoryInterface;
@@ -26,4 +27,11 @@ interface MatchRepositoryInterface extends PaginatableRepositoryInterface
     public function findBySummonerPuuid(string $puuid, int $offset, int $limit): array;
 
     public function countBySummonerPuuid(string $puuid): int;
+
+    /**
+     * @return Matche[]
+     */
+    public function findPaginatedWithFilters(int $offset, int $limit, MatchFilters $filters): array;
+
+    public function countWithFilters(MatchFilters $filters): int;
 }

--- a/src/Match/Infrastructure/Persistence/Doctrine/Repository/DoctrineMatchRepository.php
+++ b/src/Match/Infrastructure/Persistence/Doctrine/Repository/DoctrineMatchRepository.php
@@ -9,6 +9,7 @@ use App\GameData\Infrastructure\Persistence\Doctrine\Entity\GameTypeEntity;
 use App\GameData\Infrastructure\Persistence\Doctrine\Entity\MapEntity;
 use App\GameData\Infrastructure\Persistence\Doctrine\Entity\QueueEntity;
 use App\GameData\Infrastructure\Persistence\Doctrine\Entity\VersionEntity;
+use App\Match\Application\Filter\MatchFilters;
 use App\Match\Domain\Model\Matche;
 use App\Match\Domain\Repository\MatchRepositoryInterface;
 use App\Match\Domain\ValueObjet\MatchId;
@@ -164,5 +165,32 @@ final class DoctrineMatchRepository implements MatchRepositoryInterface
             ->setParameter('puuid', $puuid)
             ->getQuery()
             ->getSingleScalarResult();
+    }
+
+    public function findPaginatedWithFilters(int $offset, int $limit, MatchFilters $filters): array
+    {
+        $qb = $this->em->getRepository(MatchEntity::class)
+            ->createQueryBuilder('m')
+            ->orderBy('m.playedAt', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit);
+
+        $filters->apply($qb);
+
+        return array_map(
+            static fn (MatchEntity $entity): Matche => $entity->toDomain(),
+            $qb->getQuery()->getResult(),
+        );
+    }
+
+    public function countWithFilters(MatchFilters $filters): int
+    {
+        $qb = $this->em->getRepository(MatchEntity::class)
+            ->createQueryBuilder('m')
+            ->select('COUNT(m.id)');
+
+        $filters->apply($qb);
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
     }
 }

--- a/src/Match/Presentation/Api/ListMatchesController.php
+++ b/src/Match/Presentation/Api/ListMatchesController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Match\Presentation\Api;
 
+use App\Match\Application\Filter\MatchFiltersFactory;
 use App\Match\Application\Query\ListMatchesQuery;
 use App\Match\Application\ReadModel\MatchReadModel;
 use App\SharedContext\Application\Bus\QueryBusInterface;
@@ -27,9 +28,17 @@ final class ListMatchesController extends AbstractController
         $page = $request->query->getInt('page', 1);
         $limit = $request->query->getInt('limit', 20);
 
+        $filters = MatchFiltersFactory::fromQueryParams(
+            platform: $request->query->getString('platform') ?: null,
+            gameMode: $request->query->getString('gameMode') ?: null,
+            version: $request->query->getString('version') ?: null,
+            dateFrom: $request->query->getString('dateFrom') ?: null,
+            dateTo: $request->query->getString('dateTo') ?: null,
+        );
+
         /** @var PaginatedResult<MatchReadModel> $result */
         $result = $this->queryBus->handle(
-            new ListMatchesQuery(new PaginationRequest($page, $limit))
+            new ListMatchesQuery(new PaginationRequest($page, $limit), $filters)
         );
 
         return $this->json([

--- a/tests/Functional/Match/Application/QueryHandler/ListMatchesHandlerTest.php
+++ b/tests/Functional/Match/Application/QueryHandler/ListMatchesHandlerTest.php
@@ -4,9 +4,16 @@ declare(strict_types=1);
 
 namespace App\Tests\Functional\Match\Application\QueryHandler;
 
+use App\Match\Application\Filter\MatchFilters;
+use App\Match\Application\Filter\Specification\DateFromSpecification;
+use App\Match\Application\Filter\Specification\DateToSpecification;
+use App\Match\Application\Filter\Specification\GameModeSpecification;
+use App\Match\Application\Filter\Specification\PlatformSpecification;
+use App\Match\Application\Filter\Specification\VersionSpecification;
 use App\Match\Application\Query\ListMatchesQuery;
 use App\SharedContext\Domain\Pagination\PaginatedResult;
 use App\SharedContext\Domain\Pagination\PaginationRequest;
+use App\Tests\Factory\GameModeEntityFactory;
 use App\Tests\Factory\MatchEntityFactory;
 use App\Tests\Factory\VersionEntityFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -147,5 +154,180 @@ final class ListMatchesHandlerTest extends KernelTestCase
         $this->assertSame(5, $result->total);
         $this->assertSame(1, $result->page);
         $this->assertSame(3, $result->totalPages);
+    }
+
+    public function testFilterByPlatform(): void
+    {
+        // Given: matches on different platforms
+        MatchEntityFactory::createMany(3, ['platform' => 'euw1']);
+        MatchEntityFactory::createMany(2, ['platform' => 'na1']);
+
+        // When: filtering by euw1
+        $envelope = $this->queryBus->dispatch(
+            new ListMatchesQuery(filters: new MatchFilters(new PlatformSpecification('euw1')))
+        );
+        $result = $envelope->last(HandledStamp::class)?->getResult();
+
+        // Then: should return only euw1 matches
+        $this->assertInstanceOf(PaginatedResult::class, $result);
+        $this->assertCount(3, $result->items);
+        $this->assertSame(3, $result->total);
+
+        foreach ($result->items as $item) {
+            $this->assertSame('euw1', $item->platform);
+        }
+    }
+
+    public function testFilterByGameMode(): void
+    {
+        // Given: matches with different game modes
+        $classic = GameModeEntityFactory::new()->classic()->create();
+        $aram = GameModeEntityFactory::new()->aram()->create();
+
+        MatchEntityFactory::createMany(4, ['gameMode' => $classic]);
+        MatchEntityFactory::createMany(2, ['gameMode' => $aram]);
+
+        // When: filtering by CLASSIC
+        $envelope = $this->queryBus->dispatch(
+            new ListMatchesQuery(filters: new MatchFilters(new GameModeSpecification('CLASSIC')))
+        );
+        $result = $envelope->last(HandledStamp::class)?->getResult();
+
+        // Then: should return only CLASSIC matches
+        $this->assertInstanceOf(PaginatedResult::class, $result);
+        $this->assertCount(4, $result->items);
+        $this->assertSame(4, $result->total);
+
+        foreach ($result->items as $item) {
+            $this->assertSame('CLASSIC', $item->gameMode);
+        }
+    }
+
+    public function testFilterByVersion(): void
+    {
+        // Given: matches with different versions
+        $v14 = VersionEntityFactory::createOne(['version' => '14.6.1']);
+        $v15 = VersionEntityFactory::createOne(['version' => '15.1.1']);
+
+        MatchEntityFactory::createMany(3, ['version' => $v14]);
+        MatchEntityFactory::createMany(2, ['version' => $v15]);
+
+        // When: filtering by version prefix 14.6
+        $envelope = $this->queryBus->dispatch(
+            new ListMatchesQuery(filters: new MatchFilters(new VersionSpecification('14.6')))
+        );
+        $result = $envelope->last(HandledStamp::class)?->getResult();
+
+        // Then: should return only 14.6.x matches
+        $this->assertInstanceOf(PaginatedResult::class, $result);
+        $this->assertCount(3, $result->items);
+        $this->assertSame(3, $result->total);
+    }
+
+    public function testFilterByDateFrom(): void
+    {
+        // Given: matches at different dates
+        MatchEntityFactory::createOne(['playedAt' => new \DateTime('2024-01-10')]);
+        MatchEntityFactory::createOne(['playedAt' => new \DateTime('2024-03-15')]);
+        MatchEntityFactory::createOne(['playedAt' => new \DateTime('2024-06-20')]);
+
+        // When: filtering from 2024-03-01
+        $envelope = $this->queryBus->dispatch(
+            new ListMatchesQuery(filters: new MatchFilters(
+                new DateFromSpecification(new \DateTimeImmutable('2024-03-01 00:00:00'))
+            ))
+        );
+        $result = $envelope->last(HandledStamp::class)?->getResult();
+
+        // Then: should return 2 matches on or after 2024-03-01
+        $this->assertInstanceOf(PaginatedResult::class, $result);
+        $this->assertCount(2, $result->items);
+        $this->assertSame(2, $result->total);
+    }
+
+    public function testFilterByDateTo(): void
+    {
+        // Given: matches at different dates
+        MatchEntityFactory::createOne(['playedAt' => new \DateTime('2024-01-10')]);
+        MatchEntityFactory::createOne(['playedAt' => new \DateTime('2024-03-15')]);
+        MatchEntityFactory::createOne(['playedAt' => new \DateTime('2024-06-20')]);
+
+        // When: filtering up to 2024-03-31
+        $envelope = $this->queryBus->dispatch(
+            new ListMatchesQuery(filters: new MatchFilters(
+                new DateToSpecification(new \DateTimeImmutable('2024-03-31 23:59:59'))
+            ))
+        );
+        $result = $envelope->last(HandledStamp::class)?->getResult();
+
+        // Then: should return 2 matches on or before 2024-03-31
+        $this->assertInstanceOf(PaginatedResult::class, $result);
+        $this->assertCount(2, $result->items);
+        $this->assertSame(2, $result->total);
+    }
+
+    public function testFilterByDateRange(): void
+    {
+        // Given: matches spread across the year
+        MatchEntityFactory::createOne(['playedAt' => new \DateTime('2024-01-10')]);
+        MatchEntityFactory::createOne(['playedAt' => new \DateTime('2024-04-05')]);
+        MatchEntityFactory::createOne(['playedAt' => new \DateTime('2024-07-20')]);
+        MatchEntityFactory::createOne(['playedAt' => new \DateTime('2024-11-01')]);
+
+        // When: filtering between 2024-03-01 and 2024-08-31
+        $envelope = $this->queryBus->dispatch(
+            new ListMatchesQuery(filters: new MatchFilters(
+                new DateFromSpecification(new \DateTimeImmutable('2024-03-01 00:00:00')),
+                new DateToSpecification(new \DateTimeImmutable('2024-08-31 23:59:59')),
+            ))
+        );
+        $result = $envelope->last(HandledStamp::class)?->getResult();
+
+        // Then: should return only the 2 matches within range
+        $this->assertInstanceOf(PaginatedResult::class, $result);
+        $this->assertCount(2, $result->items);
+        $this->assertSame(2, $result->total);
+    }
+
+    public function testCombinedFilters(): void
+    {
+        // Given: matches with various combinations
+        $classic = GameModeEntityFactory::new()->classic()->create();
+        $aram = GameModeEntityFactory::new()->aram()->create();
+
+        MatchEntityFactory::createMany(2, ['platform' => 'euw1', 'gameMode' => $classic]);
+        MatchEntityFactory::createMany(2, ['platform' => 'euw1', 'gameMode' => $aram]);
+        MatchEntityFactory::createMany(2, ['platform' => 'na1', 'gameMode' => $classic]);
+
+        // When: filtering by euw1 + CLASSIC
+        $envelope = $this->queryBus->dispatch(
+            new ListMatchesQuery(filters: new MatchFilters(
+                new PlatformSpecification('euw1'),
+                new GameModeSpecification('CLASSIC'),
+            ))
+        );
+        $result = $envelope->last(HandledStamp::class)?->getResult();
+
+        // Then: should return only euw1 CLASSIC matches
+        $this->assertInstanceOf(PaginatedResult::class, $result);
+        $this->assertCount(2, $result->items);
+        $this->assertSame(2, $result->total);
+    }
+
+    public function testFilterWithNoMatchingResults(): void
+    {
+        // Given: matches on euw1 only
+        MatchEntityFactory::createMany(3, ['platform' => 'euw1']);
+
+        // When: filtering by kr (no matches)
+        $envelope = $this->queryBus->dispatch(
+            new ListMatchesQuery(filters: new MatchFilters(new PlatformSpecification('kr')))
+        );
+        $result = $envelope->last(HandledStamp::class)?->getResult();
+
+        // Then: should return empty result
+        $this->assertInstanceOf(PaginatedResult::class, $result);
+        $this->assertCount(0, $result->items);
+        $this->assertSame(0, $result->total);
     }
 }

--- a/tests/Unit/Match/Application/Filter/MatchFiltersFactoryTest.php
+++ b/tests/Unit/Match/Application/Filter/MatchFiltersFactoryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Match\Application\Filter;
+
+use App\Match\Application\Filter\MatchFilters;
+use App\Match\Application\Filter\MatchFiltersFactory;
+use PHPUnit\Framework\TestCase;
+
+final class MatchFiltersFactoryTest extends TestCase
+{
+    public function testReturnsEmptyFiltersWhenAllParamsAreNull(): void
+    {
+        $filters = MatchFiltersFactory::fromQueryParams(null, null, null, null, null);
+
+        $this->assertInstanceOf(MatchFilters::class, $filters);
+        $this->assertTrue($filters->isEmpty());
+    }
+
+    public function testReturnsNonEmptyFiltersWhenPlatformIsSet(): void
+    {
+        $filters = MatchFiltersFactory::fromQueryParams(platform: 'euw1', gameMode: null, version: null, dateFrom: null, dateTo: null);
+
+        $this->assertFalse($filters->isEmpty());
+    }
+
+    public function testReturnsNonEmptyFiltersWhenGameModeIsSet(): void
+    {
+        $filters = MatchFiltersFactory::fromQueryParams(platform: null, gameMode: 'CLASSIC', version: null, dateFrom: null, dateTo: null);
+
+        $this->assertFalse($filters->isEmpty());
+    }
+
+    public function testReturnsNonEmptyFiltersWhenVersionIsSet(): void
+    {
+        $filters = MatchFiltersFactory::fromQueryParams(platform: null, gameMode: null, version: '14.6', dateFrom: null, dateTo: null);
+
+        $this->assertFalse($filters->isEmpty());
+    }
+
+    public function testReturnsNonEmptyFiltersWhenDateFromIsSet(): void
+    {
+        $filters = MatchFiltersFactory::fromQueryParams(platform: null, gameMode: null, version: null, dateFrom: '2024-01-01', dateTo: null);
+
+        $this->assertFalse($filters->isEmpty());
+    }
+
+    public function testReturnsNonEmptyFiltersWhenDateToIsSet(): void
+    {
+        $filters = MatchFiltersFactory::fromQueryParams(platform: null, gameMode: null, version: null, dateFrom: null, dateTo: '2024-12-31');
+
+        $this->assertFalse($filters->isEmpty());
+    }
+
+    public function testReturnsNonEmptyFiltersWhenAllParamsAreSet(): void
+    {
+        $filters = MatchFiltersFactory::fromQueryParams('euw1', 'CLASSIC', '14.6', '2024-01-01', '2024-12-31');
+
+        $this->assertFalse($filters->isEmpty());
+    }
+}

--- a/tests/Unit/Match/Application/Filter/Specification/DateFromSpecificationTest.php
+++ b/tests/Unit/Match/Application/Filter/Specification/DateFromSpecificationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Match\Application\Filter\Specification;
+
+use App\Match\Application\Filter\Specification\DateFromSpecification;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class DateFromSpecificationTest extends TestCase
+{
+    public function testAppliesWhereClause(): void
+    {
+        $date = new \DateTimeImmutable('2024-01-01 00:00:00');
+
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->once())
+            ->method('andWhere')
+            ->with('m.playedAt >= :dateFrom')
+            ->willReturnSelf();
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('dateFrom', $date)
+            ->willReturnSelf();
+
+        (new DateFromSpecification($date))->apply($qb);
+    }
+}

--- a/tests/Unit/Match/Application/Filter/Specification/DateToSpecificationTest.php
+++ b/tests/Unit/Match/Application/Filter/Specification/DateToSpecificationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Match\Application\Filter\Specification;
+
+use App\Match\Application\Filter\Specification\DateToSpecification;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class DateToSpecificationTest extends TestCase
+{
+    public function testAppliesWhereClause(): void
+    {
+        $date = new \DateTimeImmutable('2024-12-31 23:59:59');
+
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->once())
+            ->method('andWhere')
+            ->with('m.playedAt <= :dateTo')
+            ->willReturnSelf();
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('dateTo', $date)
+            ->willReturnSelf();
+
+        (new DateToSpecification($date))->apply($qb);
+    }
+}

--- a/tests/Unit/Match/Application/Filter/Specification/GameModeSpecificationTest.php
+++ b/tests/Unit/Match/Application/Filter/Specification/GameModeSpecificationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Match\Application\Filter\Specification;
+
+use App\Match\Application\Filter\Specification\GameModeSpecification;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class GameModeSpecificationTest extends TestCase
+{
+    public function testAppliesJoinAndWhereClause(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->once())
+            ->method('innerJoin')
+            ->with('m.gameMode', 'gm')
+            ->willReturnSelf();
+
+        $qb->expects($this->once())
+            ->method('andWhere')
+            ->with('gm.gameMode = :gameMode')
+            ->willReturnSelf();
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('gameMode', 'CLASSIC')
+            ->willReturnSelf();
+
+        (new GameModeSpecification('CLASSIC'))->apply($qb);
+    }
+}

--- a/tests/Unit/Match/Application/Filter/Specification/PlatformSpecificationTest.php
+++ b/tests/Unit/Match/Application/Filter/Specification/PlatformSpecificationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Match\Application\Filter\Specification;
+
+use App\Match\Application\Filter\Specification\PlatformSpecification;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class PlatformSpecificationTest extends TestCase
+{
+    public function testAppliesWhereClause(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->once())
+            ->method('andWhere')
+            ->with('m.platform = :platform')
+            ->willReturnSelf();
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('platform', 'euw1')
+            ->willReturnSelf();
+
+        (new PlatformSpecification('euw1'))->apply($qb);
+    }
+}

--- a/tests/Unit/Match/Application/Filter/Specification/VersionSpecificationTest.php
+++ b/tests/Unit/Match/Application/Filter/Specification/VersionSpecificationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Match\Application\Filter\Specification;
+
+use App\Match\Application\Filter\Specification\VersionSpecification;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class VersionSpecificationTest extends TestCase
+{
+    public function testAppliesJoinAndLikeClause(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->once())
+            ->method('innerJoin')
+            ->with('m.version', 'v')
+            ->willReturnSelf();
+
+        $qb->expects($this->once())
+            ->method('andWhere')
+            ->with('v.version LIKE :version')
+            ->willReturnSelf();
+
+        $qb->expects($this->once())
+            ->method('setParameter')
+            ->with('version', '14.6%')
+            ->willReturnSelf();
+
+        (new VersionSpecification('14.6'))->apply($qb);
+    }
+}

--- a/tests/Unit/Match/Application/Query/MatchFiltersTest.php
+++ b/tests/Unit/Match/Application/Query/MatchFiltersTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Match\Application\Query;
+
+use App\Match\Application\Filter\MatchFilters;
+use App\Match\Application\Filter\MatchFilterSpecificationInterface;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class MatchFiltersTest extends TestCase
+{
+    public function testIsEmptyWithNoSpecifications(): void
+    {
+        $this->assertTrue((new MatchFilters())->isEmpty());
+    }
+
+    public function testIsNotEmptyWithOneSpecification(): void
+    {
+        $spec = $this->createStub(MatchFilterSpecificationInterface::class);
+
+        $this->assertFalse((new MatchFilters($spec))->isEmpty());
+    }
+
+    public function testIsNotEmptyWithMultipleSpecifications(): void
+    {
+        $spec1 = $this->createStub(MatchFilterSpecificationInterface::class);
+        $spec2 = $this->createStub(MatchFilterSpecificationInterface::class);
+
+        $this->assertFalse((new MatchFilters($spec1, $spec2))->isEmpty());
+    }
+
+    public function testApplyCallsEachSpecification(): void
+    {
+        $qb = $this->createStub(QueryBuilder::class);
+
+        $spec1 = $this->createMock(MatchFilterSpecificationInterface::class);
+        $spec1->expects($this->once())->method('apply')->with($qb);
+
+        $spec2 = $this->createMock(MatchFilterSpecificationInterface::class);
+        $spec2->expects($this->once())->method('apply')->with($qb);
+
+        (new MatchFilters($spec1, $spec2))->apply($qb);
+    }
+
+    public function testApplyWithNoSpecificationsDoesNothing(): void
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->never())->method($this->anything());
+
+        (new MatchFilters())->apply($qb);
+    }
+}

--- a/tests/Unit/Match/Application/QueryHandler/ListMatchesHandlerTest.php
+++ b/tests/Unit/Match/Application/QueryHandler/ListMatchesHandlerTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Match\Application\QueryHandler;
 
+use App\Match\Application\Filter\MatchFilters;
+use App\Match\Application\Filter\Specification\GameModeSpecification;
+use App\Match\Application\Filter\Specification\PlatformSpecification;
+use App\Match\Application\Filter\Specification\VersionSpecification;
 use App\Match\Application\Query\ListMatchesQuery;
 use App\Match\Application\QueryHandler\ListMatchesHandler;
 use App\Match\Application\ReadModel\MatchReadModel;
@@ -146,6 +150,84 @@ final class ListMatchesHandlerTest extends TestCase
         $this->repository
             ->expects($this->once())
             ->method('count')
+            ->willReturn(0);
+
+        ($this->handler)($query);
+    }
+
+    public function testUsesFilteredMethodsWhenFiltersAreNotEmpty(): void
+    {
+        $filters = new MatchFilters(new PlatformSpecification('euw1'));
+        $query = new ListMatchesQuery(new PaginationRequest(1, 20), $filters);
+
+        $this->repository
+            ->expects($this->never())
+            ->method('findPaginated');
+
+        $this->repository
+            ->expects($this->never())
+            ->method('count');
+
+        $this->repository
+            ->expects($this->once())
+            ->method('findPaginatedWithFilters')
+            ->with(0, 20, $filters)
+            ->willReturn([]);
+
+        $this->repository
+            ->expects($this->once())
+            ->method('countWithFilters')
+            ->with($filters)
+            ->willReturn(0);
+
+        $result = ($this->handler)($query);
+
+        $this->assertInstanceOf(PaginatedResult::class, $result);
+        $this->assertSame(0, $result->total);
+    }
+
+    public function testFilteredResultsAreMappedToReadModels(): void
+    {
+        $filters = new MatchFilters(new GameModeSpecification('CLASSIC'));
+        $query = new ListMatchesQuery(new PaginationRequest(1, 20), $filters);
+
+        $matches = [
+            $this->createMatch('EUW1_FILTERED_1', 111),
+            $this->createMatch('EUW1_FILTERED_2', 222),
+        ];
+
+        $this->repository
+            ->expects($this->once())
+            ->method('findPaginatedWithFilters')
+            ->willReturn($matches);
+
+        $this->repository
+            ->expects($this->once())
+            ->method('countWithFilters')
+            ->willReturn(2);
+
+        $result = ($this->handler)($query);
+
+        $this->assertCount(2, $result->items);
+        $this->assertContainsOnlyInstancesOf(MatchReadModel::class, $result->items);
+        $this->assertSame('EUW1_FILTERED_1', $result->items[0]->id);
+        $this->assertSame('EUW1_FILTERED_2', $result->items[1]->id);
+        $this->assertSame(2, $result->total);
+    }
+
+    public function testFiltersWithPaginationPassCorrectOffset(): void
+    {
+        $filters = new MatchFilters(new VersionSpecification('14.6'));
+        $query = new ListMatchesQuery(new PaginationRequest(3, 10), $filters);
+
+        $this->repository
+            ->expects($this->once())
+            ->method('findPaginatedWithFilters')
+            ->with(20, 10, $filters)
+            ->willReturn([]);
+
+        $this->repository
+            ->method('countWithFilters')
             ->willReturn(0);
 
         ($this->handler)($query);


### PR DESCRIPTION
- Add MatchFilters DTO in Application/Filter with isEmpty() helper
- Extend ListMatchesQuery to carry filters alongside pagination
- Add findPaginatedWithFilters / countWithFilters to repository interface and Doctrine implementation (JOIN on gameMode/version, WHERE on platform and dates)
- Update ListMatchesController to read query params: platform, gameMode, version, dateFrom, dateTo
- Update matchApi.ts to build filter query string and expose MatchFilters type
- Replace hard-coded PLATFORMS/GAME_MODES constants in MatchList.vue with dynamic API calls (getPlatforms, getGameModes, getVersions)
- Add unit tests for MatchFilters and ListMatchesHandler filter routing
- Add functional tests covering all filter combinations