### PR TITLE
feat/searchable-select-filters

### DIFF
--- a/assets/admin/views/MatchList.vue
+++ b/assets/admin/views/MatchList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { RouterLink } from 'vue-router'
 import { matchApi } from '@shared/api/matchApi'
 import { api } from '@shared/api/client'
@@ -9,11 +9,22 @@ import { usePagination } from '@shared/composables/usePagination'
 import { useTableControls } from '@shared/composables/useTableControls'
 import PaginationBar from '@shared/components/PaginationBar.vue'
 import SortableHeader from '@shared/components/SortableHeader.vue'
+import SearchableSelect from '@shared/components/SearchableSelect.vue'
 import AdminPageTemplate from '@admin/components/templates/AdminPageTemplate.vue'
 
 const platforms = ref<Platform[]>([])
 const gameModes = ref<GameMode[]>([])
 const versions = ref<Version[]>([])
+
+const platformOptions = computed(() =>
+  platforms.value.map((p) => ({ value: p.value, label: p.label })),
+)
+const gameModeOptions = computed(() =>
+  gameModes.value.map((m) => ({ value: m.gameMode, label: m.gameMode })),
+)
+const versionOptions = computed(() =>
+  versions.value.map((v) => ({ value: v.version, label: v.version })),
+)
 
 const filters = ref<MatchFilters>({
   platform: '',
@@ -98,24 +109,23 @@ function formatDate(dateString: string): string {
           placeholder="Rechercher dans la page courante..."
         />
 
-        <select v-model="filters.platform" class="table-filter-select">
-          <option value="">Toutes les plateformes</option>
-          <option v-for="p in platforms" :key="p.value" :value="p.value">{{ p.label }}</option>
-        </select>
+        <SearchableSelect
+          v-model="filters.platform"
+          :options="platformOptions"
+          placeholder="Toutes les plateformes"
+        />
 
-        <select v-model="filters.gameMode" class="table-filter-select">
-          <option value="">Tous les modes</option>
-          <option v-for="m in gameModes" :key="m.gameMode" :value="m.gameMode">
-            {{ m.gameMode }}
-          </option>
-        </select>
+        <SearchableSelect
+          v-model="filters.gameMode"
+          :options="gameModeOptions"
+          placeholder="Tous les modes"
+        />
 
-        <select v-model="filters.version" class="table-filter-select">
-          <option value="">Toutes les versions</option>
-          <option v-for="v in versions" :key="v.version" :value="v.version">
-            {{ v.version }}
-          </option>
-        </select>
+        <SearchableSelect
+          v-model="filters.version"
+          :options="versionOptions"
+          placeholder="Toutes les versions"
+        />
 
         <div class="flex items-center gap-1">
           <input

--- a/assets/shared/components/SearchableSelect.vue
+++ b/assets/shared/components/SearchableSelect.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { ref, computed, watch, onUnmounted } from 'vue'
+
+export interface SelectOption {
+  value: string
+  label: string
+}
+
+const props = defineProps<{
+  modelValue: string | undefined
+  options: SelectOption[]
+  placeholder?: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const isOpen = ref(false)
+const search = ref('')
+const containerRef = ref<HTMLElement | null>(null)
+
+const selectedLabel = computed(() =>
+  props.modelValue ? (props.options.find((o) => o.value === props.modelValue)?.label ?? '') : '',
+)
+
+const filteredOptions = computed(() => {
+  const q = search.value.toLowerCase()
+  return q ? props.options.filter((o) => o.label.toLowerCase().includes(q)) : props.options
+})
+
+function open() {
+  isOpen.value = true
+  search.value = ''
+}
+
+function select(value: string) {
+  emit('update:modelValue', value)
+  isOpen.value = false
+  search.value = ''
+}
+
+function clear() {
+  emit('update:modelValue', '')
+  isOpen.value = false
+  search.value = ''
+}
+
+function onClickOutside(event: MouseEvent) {
+  if (containerRef.value && !containerRef.value.contains(event.target as Node)) {
+    isOpen.value = false
+    search.value = ''
+  }
+}
+
+watch(isOpen, (val) => {
+  if (val) {
+    document.addEventListener('mousedown', onClickOutside)
+  } else {
+    document.removeEventListener('mousedown', onClickOutside)
+  }
+})
+
+onUnmounted(() => {
+  document.removeEventListener('mousedown', onClickOutside)
+})
+</script>
+
+<template>
+  <div ref="containerRef" class="searchable-select">
+    <!-- Trigger -->
+    <div
+      class="searchable-select__trigger"
+      :class="{ 'searchable-select__trigger--active': isOpen }"
+      @click="open"
+    >
+      <template v-if="isOpen">
+        <input
+          v-model="search"
+          class="searchable-select__input"
+          :placeholder="selectedLabel || placeholder"
+          autofocus
+          @click.stop
+        />
+      </template>
+      <template v-else>
+        <span :class="modelValue ? 'text-lol-text' : 'text-lol-muted'">
+          {{ selectedLabel || placeholder }}
+        </span>
+        <button
+          v-if="modelValue"
+          class="searchable-select__clear"
+          @click.stop="clear"
+          type="button"
+        >
+          ✕
+        </button>
+        <span v-else class="searchable-select__chevron">▾</span>
+      </template>
+    </div>
+
+    <!-- Dropdown -->
+    <ul v-if="isOpen" class="searchable-select__dropdown">
+      <li
+        v-if="!filteredOptions.length"
+        class="searchable-select__option searchable-select__option--empty"
+      >
+        Aucun résultat
+      </li>
+      <li
+        v-for="option in filteredOptions"
+        :key="option.value"
+        class="searchable-select__option"
+        :class="{ 'searchable-select__option--selected': option.value === modelValue }"
+        @mousedown.prevent="select(option.value)"
+      >
+        {{ option.label }}
+      </li>
+    </ul>
+  </div>
+</template>

--- a/assets/shared/tailwind.css
+++ b/assets/shared/tailwind.css
@@ -139,4 +139,47 @@
   .table-filter-input {
     @apply px-3 py-2 text-sm border border-lol-border rounded bg-lol-bg text-lol-text placeholder:text-lol-muted focus:outline-none focus:border-lol-gold;
   }
+
+  .searchable-select {
+    @apply relative text-sm;
+  }
+
+  .searchable-select__trigger {
+    @apply flex items-center justify-between gap-2 px-3 py-2 border border-lol-border rounded bg-lol-bg text-lol-text cursor-pointer min-w-[160px];
+    &:hover {
+      @apply border-lol-gold;
+    }
+  }
+
+  .searchable-select__trigger--active {
+    @apply border-lol-gold;
+  }
+
+  .searchable-select__input {
+    @apply bg-transparent text-lol-text placeholder:text-lol-muted outline-none w-full;
+  }
+
+  .searchable-select__clear {
+    @apply text-lol-muted hover:text-lol-text leading-none;
+  }
+
+  .searchable-select__chevron {
+    @apply text-lol-muted text-xs;
+  }
+
+  .searchable-select__dropdown {
+    @apply absolute z-50 top-full left-0 mt-1 w-full max-h-52 overflow-y-auto border border-lol-border rounded bg-lol-card shadow-lg;
+  }
+
+  .searchable-select__option {
+    @apply px-3 py-2 cursor-pointer hover:bg-lol-border text-lol-text;
+  }
+
+  .searchable-select__option--selected {
+    @apply text-lol-gold;
+  }
+
+  .searchable-select__option--empty {
+    @apply text-lol-muted cursor-default;
+  }
 }

--- a/src/Match/Infrastructure/Persistence/Doctrine/Repository/DoctrineMatchRepository.php
+++ b/src/Match/Infrastructure/Persistence/Doctrine/Repository/DoctrineMatchRepository.php
@@ -143,7 +143,7 @@ final class DoctrineMatchRepository implements MatchRepositoryInterface
             ->innerJoin('m.participants', 'p')
             ->where('p.summonerId = :puuid')
             ->setParameter('puuid', $puuid)
-            ->orderBy('m.id', 'DESC')
+            ->orderBy('m.playedAt', 'DESC')
             ->setFirstResult($offset)
             ->setMaxResults($limit)
             ->getQuery()

--- a/src/Summoner/Infrastructure/Persistence/Doctrine/Repository/DoctrineSummonerRepository.php
+++ b/src/Summoner/Infrastructure/Persistence/Doctrine/Repository/DoctrineSummonerRepository.php
@@ -72,7 +72,7 @@ final readonly class DoctrineSummonerRepository implements SummonerRepositoryInt
     {
         $entities = $this->entityManager->getRepository(SummonerEntity::class)
             ->createQueryBuilder('s')
-            ->orderBy('s.gameName', 'DESC')
+            ->orderBy('s.gameName', 'ASC')
             ->setFirstResult($offset)
             ->setMaxResults($limit)
             ->getQuery()


### PR DESCRIPTION
Add a shared SearchableSelect molecule with search-as-you-type support
and wire it to the platform, game mode and version filters in MatchList.
Add corresponding BEM utility classes in tailwind.css and fix the
missing bg-lol-surface token (replaced by bg-lol-card).

Sort matches by playedAt DESC (was id DESC) so newest matches appear
first regardless of insertion order. Sort summoners by gameName ASC
(was DESC) for natural alphabetical listing.