### PR TITLE
feat(league): display gameName#tagLine in leaderboard instead of puuid

### DIFF
--- a/assets/admin/components/organisms/AdminSidebar.vue
+++ b/assets/admin/components/organisms/AdminSidebar.vue
@@ -6,6 +6,7 @@ import {
   Users,
   Database,
   Trophy,
+  Medal,
   LogOut,
   PanelLeftClose,
   PanelLeftOpen,
@@ -29,6 +30,7 @@ const navItems = [
   { to: '/summoners', icon: Users, label: 'Summoners' },
   { to: '/game-data', icon: Database, label: 'Game Data' },
   { to: '/league-import', icon: Trophy, label: 'League Import' },
+  { to: '/league-leaderboard', icon: Medal, label: 'Leaderboard' },
 ]
 
 function isActive(to: string, exact = false) {
@@ -39,7 +41,7 @@ function isActive(to: string, exact = false) {
 
 <template>
   <aside
-    class="min-h-screen bg-admin-sidebar border-r border-admin-border flex flex-col shrink-0 transition-[width] duration-300 ease-in-out overflow-hidden"
+    class="h-screen bg-admin-sidebar border-r border-admin-border flex flex-col shrink-0 transition-[width] duration-300 ease-in-out overflow-hidden sticky top-0"
     :class="sidebar.collapsed ? 'w-16' : 'w-64'"
   >
     <!-- Logo -->
@@ -62,7 +64,7 @@ function isActive(to: string, exact = false) {
 
     <!-- Navigation -->
     <nav
-      class="flex-1 py-5 space-y-0.5 overflow-hidden"
+      class="flex-1 py-5 space-y-0.5 overflow-y-auto overflow-x-hidden"
       :class="sidebar.collapsed ? 'px-2' : 'px-3'"
     >
       <Transition name="fade">

--- a/assets/admin/views/LeagueLeaderboard.vue
+++ b/assets/admin/views/LeagueLeaderboard.vue
@@ -170,7 +170,14 @@ onMounted(() => fetchEntries(1))
         <tbody>
           <tr v-for="entry in entries" :key="entry.puuid">
             <td class="text-lol-muted text-sm">{{ entry.rank }}</td>
-            <td class="font-mono text-xs text-lol-muted">{{ entry.puuid.slice(0, 16) }}…</td>
+            <td class="font-medium text-lol-text">
+              <template v-if="entry.gameName">
+                {{ entry.gameName }}<span class="text-lol-muted">#{{ entry.tagLine }}</span>
+              </template>
+              <span v-else class="font-mono text-xs text-lol-muted"
+                >{{ entry.puuid.slice(0, 16) }}…</span
+              >
+            </td>
             <td class="text-right font-semibold" :class="tierColor(tier)">
               {{ entry.leaguePoints }} LP
             </td>

--- a/assets/shared/types/index.ts
+++ b/assets/shared/types/index.ts
@@ -97,7 +97,8 @@ export type LeagueTier = 'challenger' | 'grandmaster' | 'master'
 export interface LeagueEntry {
   rank: number
   puuid: string
-  summonerId: string
+  gameName: string | null
+  tagLine: string | null
   leaguePoints: number
   wins: number
   losses: number

--- a/src/League/Application/Dto/LeagueEntryListDto.php
+++ b/src/League/Application/Dto/LeagueEntryListDto.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace App\League\Application\Dto;
 
 use App\League\Domain\Model\LeagueEntry;
+use App\Summoner\Domain\Model\Summoner;
 
 final readonly class LeagueEntryListDto
 {
     public function __construct(
         public int $rank,
         public string $puuid,
+        public ?string $gameName,
+        public ?string $tagLine,
         public int $leaguePoints,
         public int $wins,
         public int $losses,
@@ -21,7 +24,7 @@ final readonly class LeagueEntryListDto
     ) {
     }
 
-    public static function fromDomain(LeagueEntry $entry, int $rank): self
+    public static function fromDomain(LeagueEntry $entry, int $rank, ?Summoner $summoner = null): self
     {
         $total = $entry->wins() + $entry->losses();
         $winRate = $total > 0 ? (int) round($entry->wins() / $total * 100) : 0;
@@ -29,6 +32,8 @@ final readonly class LeagueEntryListDto
         return new self(
             rank: $rank,
             puuid: $entry->puuid(),
+            gameName: $summoner?->riotId()->gameName(),
+            tagLine: $summoner?->riotId()->tagLine(),
             leaguePoints: $entry->leaguePoints(),
             wins: $entry->wins(),
             losses: $entry->losses(),

--- a/src/League/Application/QueryHandler/GetLeagueEntriesHandler.php
+++ b/src/League/Application/QueryHandler/GetLeagueEntriesHandler.php
@@ -8,6 +8,7 @@ use App\League\Application\Dto\LeagueEntryListDto;
 use App\League\Application\Query\GetLeagueEntriesQuery;
 use App\League\Domain\Repository\LeagueRepositoryInterface;
 use App\SharedContext\Domain\Pagination\PaginatedResult;
+use App\Summoner\Domain\Repository\SummonerRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler(bus: 'query.bus')]
@@ -15,6 +16,7 @@ final readonly class GetLeagueEntriesHandler
 {
     public function __construct(
         private LeagueRepositoryInterface $leagueRepository,
+        private SummonerRepositoryInterface $summonerRepository,
     ) {
     }
 
@@ -41,8 +43,15 @@ final readonly class GetLeagueEntriesHandler
         $offset = ($query->page - 1) * $query->limit;
         $page = array_slice($entries, $offset, $query->limit);
 
+        $puuids = array_map(static fn ($entry): string => $entry->puuid(), $page);
+        $summoners = $this->summonerRepository->findByPuuids($puuids);
+
         $dtos = array_map(
-            static fn ($entry, $i): LeagueEntryListDto => LeagueEntryListDto::fromDomain($entry, $offset + $i + 1),
+            static fn ($entry, $i): LeagueEntryListDto => LeagueEntryListDto::fromDomain(
+                $entry,
+                $offset + $i + 1,
+                $summoners[$entry->puuid()] ?? null,
+            ),
             $page,
             array_keys($page),
         );

--- a/src/League/Infrastructure/Persistence/Doctrine/Entity/LeagueEntryEntity.php
+++ b/src/League/Infrastructure/Persistence/Doctrine/Entity/LeagueEntryEntity.php
@@ -10,8 +10,8 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'league_entries')]
-#[ORM\Index(columns: ['puuid'], name: 'idx_league_entry_puuid')]
-#[ORM\Index(columns: ['league_id', 'league_points'], name: 'idx_league_entry_lp')]
+#[ORM\Index(name: 'idx_league_entry_puuid', columns: ['puuid'])]
+#[ORM\Index(name: 'idx_league_entry_lp', columns: ['league_id', 'league_points'])]
 class LeagueEntryEntity
 {
     #[ORM\Id]

--- a/src/Summoner/Domain/Repository/SummonerRepositoryInterface.php
+++ b/src/Summoner/Domain/Repository/SummonerRepositoryInterface.php
@@ -20,4 +20,11 @@ interface SummonerRepositoryInterface extends PaginatableRepositoryInterface
      * @return Summoner[]
      */
     public function findAll(): array;
+
+    /**
+     * @param string[] $puuids
+     *
+     * @return array<string, Summoner> indexed by puuid
+     */
+    public function findByPuuids(array $puuids): array;
 }

--- a/src/Summoner/Infrastructure/Persistence/Doctrine/Repository/DoctrineSummonerRepository.php
+++ b/src/Summoner/Infrastructure/Persistence/Doctrine/Repository/DoctrineSummonerRepository.php
@@ -84,6 +84,34 @@ final readonly class DoctrineSummonerRepository implements SummonerRepositoryInt
         );
     }
 
+    /**
+     * @param string[] $puuids
+     *
+     * @return array<string, Summoner> indexed by puuid
+     */
+    public function findByPuuids(array $puuids): array
+    {
+        if ([] === $puuids) {
+            return [];
+        }
+
+        $entities = $this->entityManager->getRepository(SummonerEntity::class)
+            ->createQueryBuilder('s')
+            ->where('s.puuid IN (:puuids)')
+            ->setParameter('puuids', $puuids)
+            ->getQuery()
+            ->getResult();
+
+        $result = [];
+
+        foreach ($entities as $entity) {
+            $summoner = $entity->toDomain();
+            $result[$summoner->puuid()->value()] = $summoner;
+        }
+
+        return $result;
+    }
+
     public function count(): int
     {
         return (int) $this->entityManager->getRepository(SummonerEntity::class)

--- a/tests/Unit/League/Application/QueryHandler/GetLeagueEntriesHandlerTest.php
+++ b/tests/Unit/League/Application/QueryHandler/GetLeagueEntriesHandlerTest.php
@@ -12,6 +12,10 @@ use App\League\Domain\Model\League;
 use App\League\Domain\Model\LeagueEntry;
 use App\League\Domain\Repository\LeagueRepositoryInterface;
 use App\SharedContext\Domain\ValueObjet\Platform;
+use App\Summoner\Domain\Model\Summoner;
+use App\Summoner\Domain\Repository\SummonerRepositoryInterface;
+use App\Summoner\Domain\ValueObject\Puuid;
+use App\Summoner\Domain\ValueObject\RiotId;
 use PHPUnit\Framework\TestCase;
 use Zeggriim\RiotApiDataDragon\Enum\Queue;
 
@@ -19,10 +23,10 @@ final class GetLeagueEntriesHandlerTest extends TestCase
 {
     public function testReturnsEmptyResultWhenLeagueNotFound(): void
     {
-        $repository = $this->createStub(LeagueRepositoryInterface::class);
-        $repository->method('findByTierQueuePlatform')->willReturn(null);
+        $leagueRepo = $this->createStub(LeagueRepositoryInterface::class);
+        $leagueRepo->method('findByTierQueuePlatform')->willReturn(null);
 
-        $result = (new GetLeagueEntriesHandler($repository))(
+        $result = (new GetLeagueEntriesHandler($leagueRepo, $this->emptySummonerRepo()))(
             new GetLeagueEntriesQuery(Platform::EUW1, LeagueTier::CHALLENGER, Queue::RANKED_SOLO),
         );
 
@@ -38,10 +42,10 @@ final class GetLeagueEntriesHandlerTest extends TestCase
             ['puuid-mid', 800],
         ]);
 
-        $repository = $this->createStub(LeagueRepositoryInterface::class);
-        $repository->method('findByTierQueuePlatform')->willReturn($league);
+        $leagueRepo = $this->createStub(LeagueRepositoryInterface::class);
+        $leagueRepo->method('findByTierQueuePlatform')->willReturn($league);
 
-        $result = (new GetLeagueEntriesHandler($repository))(
+        $result = (new GetLeagueEntriesHandler($leagueRepo, $this->emptySummonerRepo()))(
             new GetLeagueEntriesQuery(Platform::EUW1, LeagueTier::CHALLENGER, Queue::RANKED_SOLO),
         );
 
@@ -58,10 +62,10 @@ final class GetLeagueEntriesHandlerTest extends TestCase
             ['puuid-b', 1000],
         ]);
 
-        $repository = $this->createStub(LeagueRepositoryInterface::class);
-        $repository->method('findByTierQueuePlatform')->willReturn($league);
+        $leagueRepo = $this->createStub(LeagueRepositoryInterface::class);
+        $leagueRepo->method('findByTierQueuePlatform')->willReturn($league);
 
-        $result = (new GetLeagueEntriesHandler($repository))(
+        $result = (new GetLeagueEntriesHandler($leagueRepo, $this->emptySummonerRepo()))(
             new GetLeagueEntriesQuery(Platform::EUW1, LeagueTier::CHALLENGER, Queue::RANKED_SOLO),
         );
 
@@ -77,10 +81,10 @@ final class GetLeagueEntriesHandlerTest extends TestCase
         );
         $league = $this->makeLeague($entries);
 
-        $repository = $this->createStub(LeagueRepositoryInterface::class);
-        $repository->method('findByTierQueuePlatform')->willReturn($league);
+        $leagueRepo = $this->createStub(LeagueRepositoryInterface::class);
+        $leagueRepo->method('findByTierQueuePlatform')->willReturn($league);
 
-        $result = (new GetLeagueEntriesHandler($repository))(
+        $result = (new GetLeagueEntriesHandler($leagueRepo, $this->emptySummonerRepo()))(
             new GetLeagueEntriesQuery(Platform::EUW1, LeagueTier::CHALLENGER, Queue::RANKED_SOLO, page: 2, limit: 3),
         );
 
@@ -94,14 +98,84 @@ final class GetLeagueEntriesHandlerTest extends TestCase
         $entries = array_map(fn (int $i): array => ["p-{$i}", $i * 10], range(1, 7));
         $league = $this->makeLeague($entries);
 
-        $repository = $this->createStub(LeagueRepositoryInterface::class);
-        $repository->method('findByTierQueuePlatform')->willReturn($league);
+        $leagueRepo = $this->createStub(LeagueRepositoryInterface::class);
+        $leagueRepo->method('findByTierQueuePlatform')->willReturn($league);
 
-        $result = (new GetLeagueEntriesHandler($repository))(
+        $result = (new GetLeagueEntriesHandler($leagueRepo, $this->emptySummonerRepo()))(
             new GetLeagueEntriesQuery(Platform::EUW1, LeagueTier::CHALLENGER, Queue::RANKED_SOLO, page: 1, limit: 3),
         );
 
         $this->assertSame(3, $result->totalPages); // ceil(7/3) = 3
+    }
+
+    public function testGameNameAndTagLineAreSetWhenSummonerExists(): void
+    {
+        $puuid = 'puuid-known';
+        $league = $this->makeLeague([[$puuid, 1000]]);
+
+        $leagueRepo = $this->createStub(LeagueRepositoryInterface::class);
+        $leagueRepo->method('findByTierQueuePlatform')->willReturn($league);
+
+        $summoner = Summoner::create(
+            Puuid::fromString($puuid),
+            RiotId::create('Faker', 'T1'),
+            1,
+            100,
+            Platform::EUW1,
+            new \DateTimeImmutable(),
+        );
+
+        $summonerRepo = $this->createStub(SummonerRepositoryInterface::class);
+        $summonerRepo->method('findByPuuids')->willReturn([$puuid => $summoner]);
+
+        $result = (new GetLeagueEntriesHandler($leagueRepo, $summonerRepo))(
+            new GetLeagueEntriesQuery(Platform::EUW1, LeagueTier::CHALLENGER, Queue::RANKED_SOLO),
+        );
+
+        $this->assertSame('Faker', $result->items[0]->gameName);
+        $this->assertSame('T1', $result->items[0]->tagLine);
+    }
+
+    public function testGameNameAndTagLineAreNullWhenSummonerNotFound(): void
+    {
+        $league = $this->makeLeague([['puuid-unknown', 500]]);
+
+        $leagueRepo = $this->createStub(LeagueRepositoryInterface::class);
+        $leagueRepo->method('findByTierQueuePlatform')->willReturn($league);
+
+        $result = (new GetLeagueEntriesHandler($leagueRepo, $this->emptySummonerRepo()))(
+            new GetLeagueEntriesQuery(Platform::EUW1, LeagueTier::CHALLENGER, Queue::RANKED_SOLO),
+        );
+
+        $this->assertNull($result->items[0]->gameName);
+        $this->assertNull($result->items[0]->tagLine);
+    }
+
+    public function testOnlyPuuidsOfCurrentPageAreFetchedFromSummonerRepository(): void
+    {
+        $entries = array_map(fn (int $i): array => ["puuid-{$i}", 1000 - $i], range(0, 5));
+        $league = $this->makeLeague($entries);
+
+        $leagueRepo = $this->createStub(LeagueRepositoryInterface::class);
+        $leagueRepo->method('findByTierQueuePlatform')->willReturn($league);
+
+        $summonerRepo = $this->createMock(SummonerRepositoryInterface::class);
+        $summonerRepo->expects($this->once())
+            ->method('findByPuuids')
+            ->with($this->countOf(2)) // limit 2, page 2 → only 2 puuids
+            ->willReturn([]);
+
+        (new GetLeagueEntriesHandler($leagueRepo, $summonerRepo))(
+            new GetLeagueEntriesQuery(Platform::EUW1, LeagueTier::CHALLENGER, Queue::RANKED_SOLO, page: 2, limit: 2),
+        );
+    }
+
+    private function emptySummonerRepo(): SummonerRepositoryInterface
+    {
+        $stub = $this->createStub(SummonerRepositoryInterface::class);
+        $stub->method('findByPuuids')->willReturn([]);
+
+        return $stub;
     }
 
     /**


### PR DESCRIPTION
Enrich GetLeagueEntriesHandler with a bulk summoner lookup (findByPuuids) to resolve gameName and tagLine for each entry on the current page. Fall back to null when the simmoner is not yet imported