### PR TITLE
feat(summoner): add global stats cards (win rate, KDA, CS/min, favorite champion)

### DIFF
--- a/assets/front/views/SummonerDetail.vue
+++ b/assets/front/views/SummonerDetail.vue
@@ -3,15 +3,18 @@ import { ref, onMounted } from 'vue'
 import { useRoute, RouterLink } from 'vue-router'
 import { api } from '@shared/api/client'
 import { matchApi } from '@shared/api/matchApi'
+import { summonerApi } from '@shared/api/summonerApi'
 import { usePagination } from '@shared/composables/usePagination'
 import PaginationBar from '@shared/components/PaginationBar.vue'
+import SummonerStatsCards from '@shared/components/SummonerStatsCards.vue'
 import SummonerMatchCharts from '@shared/components/SummonerMatchCharts.vue'
 import ChampionIcon from '@shared/components/ChampionIcon.vue'
-import type { Summoner, Match } from '@shared/types'
+import type { Summoner, SummonerStats, Match } from '@shared/types'
 import { ChevronLeft, User, Star, Globe } from 'lucide-vue-next'
 
 const route = useRoute()
 const summoner = ref<Summoner | null>(null)
+const stats = ref<SummonerStats | null>(null)
 const loading = ref(true)
 const error = ref<string | null>(null)
 
@@ -33,8 +36,12 @@ const {
 
 onMounted(async () => {
   try {
-    const response = await api.getSummoner(puuid)
-    summoner.value = response.data
+    const [summonerRes, statsRes] = await Promise.all([
+      api.getSummoner(puuid),
+      summonerApi.getStats(puuid),
+    ])
+    summoner.value = summonerRes.data
+    stats.value = statsRes.data
     fetchPage(1)
   } catch (e) {
     error.value = 'Impossible de charger le profil'
@@ -110,6 +117,14 @@ function formatDate(dateString: string): string {
           </div>
         </div>
       </div>
+
+      <!-- Stats cards -->
+      <SummonerStatsCards
+        v-if="stats && matches.length > 0"
+        :stats="stats"
+        :version="matches[0]?.version ?? ''"
+        class="mb-2"
+      />
 
       <!-- Charts & Match History -->
       <div v-if="matchesInitialLoading" class="loading">Chargement des parties…</div>

--- a/assets/shared/api/summonerApi.ts
+++ b/assets/shared/api/summonerApi.ts
@@ -1,10 +1,11 @@
-import type { Summoner, ApiResponse, PaginatedResponse } from '@shared/types'
+import type { Summoner, SummonerStats, ApiResponse, PaginatedResponse } from '@shared/types'
 import { fetchApi } from './fetchApi'
 
 export const summonerApi = {
   getSummoners: (page = 1, limit = 20) =>
     fetchApi<PaginatedResponse<Summoner>>(`/summoners?page=${page}&limit=${limit}`),
   getSummoner: (puuid: string) => fetchApi<ApiResponse<Summoner>>(`/summoners/${puuid}`),
+  getStats: (puuid: string) => fetchApi<ApiResponse<SummonerStats>>(`/summoners/${puuid}/stats`),
   importByRiotId: (gameName: string, tagLine: string, platform: string) =>
     fetchApi<{ status: string; message: string }>('/summoners/import/riot-id', {
       method: 'POST',

--- a/assets/shared/components/SummonerStatsCards.vue
+++ b/assets/shared/components/SummonerStatsCards.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import ChampionIcon from '@shared/components/ChampionIcon.vue'
+import type { SummonerStats } from '@shared/types'
+
+defineProps<{
+  stats: SummonerStats
+  version: string
+}>()
+
+const winRateColor = (rate: number) =>
+  rate >= 55 ? 'text-lol-win' : rate >= 50 ? 'text-lol-text' : 'text-lol-loss'
+
+const kdaColor = (kda: number) =>
+  kda >= 3 ? 'text-lol-win' : kda >= 2 ? 'text-lol-gold' : 'text-lol-text'
+</script>
+
+<template>
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+    <!-- Win Rate -->
+    <div class="card flex flex-col gap-2">
+      <p class="text-xs text-lol-muted uppercase tracking-widest font-medium">Win Rate</p>
+      <p class="text-3xl font-bold" :class="winRateColor(stats.winRate)">{{ stats.winRate }}%</p>
+      <div class="flex items-center gap-2 text-sm mt-auto">
+        <span class="text-lol-win font-medium">{{ stats.wins }}V</span>
+        <span class="text-lol-muted">·</span>
+        <span class="text-lol-loss font-medium">{{ stats.losses }}D</span>
+        <span class="text-lol-muted text-xs ml-auto">{{ stats.totalGames }} parties</span>
+      </div>
+    </div>
+
+    <!-- KDA -->
+    <div class="card flex flex-col gap-2">
+      <p class="text-xs text-lol-muted uppercase tracking-widest font-medium">KDA Moyen</p>
+      <p class="text-3xl font-bold" :class="kdaColor(stats.avgKda)">
+        {{ stats.avgKda }}
+      </p>
+      <p class="text-sm text-lol-muted mt-auto">
+        <span class="text-lol-text">{{ stats.avgKills }}</span>
+        /
+        <span class="text-lol-loss">{{ stats.avgDeaths }}</span>
+        /
+        <span class="text-lol-text">{{ stats.avgAssists }}</span>
+      </p>
+    </div>
+
+    <!-- CS/min -->
+    <div class="card flex flex-col gap-2">
+      <p class="text-xs text-lol-muted uppercase tracking-widest font-medium">CS / min</p>
+      <p class="text-3xl font-bold text-lol-text">{{ stats.avgCsPerMin }}</p>
+      <p class="text-sm text-lol-muted mt-auto">{{ stats.avgCs }} CS en moyenne</p>
+    </div>
+
+    <!-- Favori champion -->
+    <div class="card flex flex-col gap-2">
+      <p class="text-xs text-lol-muted uppercase tracking-widest font-medium">Champion Favori</p>
+      <div class="flex items-center gap-3 mt-1">
+        <ChampionIcon
+          v-if="stats.favoriteChampionId"
+          :champion-id="stats.favoriteChampionId"
+          :version="version"
+          :size="48"
+          class="rounded-lg"
+        />
+        <span v-else class="text-lol-muted text-sm">—</span>
+      </div>
+      <p class="text-xs text-lol-muted mt-auto">Avg {{ stats.avgGold.toLocaleString() }} or</p>
+    </div>
+  </div>
+</template>

--- a/assets/shared/types/index.ts
+++ b/assets/shared/types/index.ts
@@ -94,6 +94,21 @@ export interface Platform {
 
 export type LeagueTier = 'challenger' | 'grandmaster' | 'master'
 
+export interface SummonerStats {
+  totalGames: number
+  wins: number
+  losses: number
+  winRate: number
+  avgKills: number
+  avgDeaths: number
+  avgAssists: number
+  avgKda: number
+  avgCs: number
+  avgCsPerMin: number
+  avgGold: number
+  favoriteChampionId: number | null
+}
+
 export interface LeagueEntry {
   rank: number
   puuid: string

--- a/config/services/summoner.yaml
+++ b/config/services/summoner.yaml
@@ -5,3 +5,6 @@ services:
     App\Summoner\Application\Port\RiotSummonerProviderInterface:
         alias: App\Summoner\Infrastructure\Adapter\RiotSummonerProvider
 
+    App\Summoner\Application\Port\SummonerMatchStatsProviderInterface:
+        alias: App\Summoner\Infrastructure\Adapter\DoctrineMatchStatsAdapter
+

--- a/src/Summoner/Application/Dto/SummonerStatsDto.php
+++ b/src/Summoner/Application/Dto/SummonerStatsDto.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Summoner\Application\Dto;
+
+final readonly class SummonerStatsDto
+{
+    public function __construct(
+        public int $totalGames,
+        public int $wins,
+        public int $losses,
+        public float $winRate,
+        public float $avgKills,
+        public float $avgDeaths,
+        public float $avgAssists,
+        public float $avgKda,
+        public float $avgCs,
+        public float $avgCsPerMin,
+        public int $avgGold,
+        public ?int $favoriteChampionId,
+    ) {
+    }
+
+    /**
+     * @param array{totalGames: int, wins: int, losses: int, avgKills: float, avgDeaths: float, avgAssists: float, avgCs: float, avgCsPerMin: float, avgGold: int, avgDurationSeconds: int, favoriteChampionId: int|null} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $winRate = $data['totalGames'] > 0
+            ? round($data['wins'] / $data['totalGames'] * 100, 1)
+            : 0.0;
+
+        $avgKda = $data['avgDeaths'] > 0
+            ? round(($data['avgKills'] + $data['avgAssists']) / $data['avgDeaths'], 2)
+            : round($data['avgKills'] + $data['avgAssists'], 2);
+
+        return new self(
+            totalGames: $data['totalGames'],
+            wins: $data['wins'],
+            losses: $data['losses'],
+            winRate: $winRate,
+            avgKills: $data['avgKills'],
+            avgDeaths: $data['avgDeaths'],
+            avgAssists: $data['avgAssists'],
+            avgKda: $avgKda,
+            avgCs: $data['avgCs'],
+            avgCsPerMin: $data['avgCsPerMin'],
+            avgGold: $data['avgGold'],
+            favoriteChampionId: $data['favoriteChampionId'],
+        );
+    }
+}

--- a/src/Summoner/Application/Port/SummonerMatchStatsProviderInterface.php
+++ b/src/Summoner/Application/Port/SummonerMatchStatsProviderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Summoner\Application\Port;
+
+interface SummonerMatchStatsProviderInterface
+{
+    /**
+     * @return array{
+     *     totalGames: int,
+     *     wins: int,
+     *     losses: int,
+     *     avgKills: float,
+     *     avgDeaths: float,
+     *     avgAssists: float,
+     *     avgCs: float,
+     *     avgCsPerMin: float,
+     *     avgGold: int,
+     *     avgDurationSeconds: int,
+     *     favoriteChampionId: int|null,
+     * }
+     */
+    public function getAggregateStatsByPuuid(string $puuid): array;
+}

--- a/src/Summoner/Application/Query/GetSummonerStatsQuery.php
+++ b/src/Summoner/Application/Query/GetSummonerStatsQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Summoner\Application\Query;
+
+use App\Summoner\Domain\ValueObject\Puuid;
+
+final readonly class GetSummonerStatsQuery
+{
+    public function __construct(public Puuid $puuid)
+    {
+    }
+}

--- a/src/Summoner/Application/QueryHandler/GetSummonerStatsHandler.php
+++ b/src/Summoner/Application/QueryHandler/GetSummonerStatsHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Summoner\Application\QueryHandler;
+
+use App\Summoner\Application\Dto\SummonerStatsDto;
+use App\Summoner\Application\Port\SummonerMatchStatsProviderInterface;
+use App\Summoner\Application\Query\GetSummonerStatsQuery;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler(bus: 'query.bus')]
+final readonly class GetSummonerStatsHandler
+{
+    public function __construct(
+        private SummonerMatchStatsProviderInterface $statsProvider,
+    ) {
+    }
+
+    public function __invoke(GetSummonerStatsQuery $query): SummonerStatsDto
+    {
+        $data = $this->statsProvider->getAggregateStatsByPuuid($query->puuid->value());
+
+        return SummonerStatsDto::fromArray($data);
+    }
+}

--- a/src/Summoner/Domain/ValueObject/Puuid.php
+++ b/src/Summoner/Domain/ValueObject/Puuid.php
@@ -12,7 +12,7 @@ final readonly class Puuid
 
     public static function fromString(string $puuid): self
     {
-        if (empty($puuid)) {
+        if ('' === $puuid) {
             throw new \InvalidArgumentException('Puuid cannot be empty');
         }
 

--- a/src/Summoner/Infrastructure/Adapter/DoctrineMatchStatsAdapter.php
+++ b/src/Summoner/Infrastructure/Adapter/DoctrineMatchStatsAdapter.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Summoner\Infrastructure\Adapter;
+
+use App\Match\Infrastructure\Persistence\Doctrine\Entity\ParticipantEntity;
+use App\Summoner\Application\Port\SummonerMatchStatsProviderInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class DoctrineMatchStatsAdapter implements SummonerMatchStatsProviderInterface
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function getAggregateStatsByPuuid(string $puuid): array
+    {
+        $aggregates = $this->em->createQueryBuilder()
+            ->select([
+                'COUNT(p.id) as totalGames',
+                'AVG(p.kills) as avgKills',
+                'AVG(p.deaths) as avgDeaths',
+                'AVG(p.assists) as avgAssists',
+                'AVG(ps.cs) as avgCs',
+                'AVG(ps.goldEarned) as avgGold',
+                'AVG(m.durationSeconds) as avgDuration',
+            ])
+            ->from(ParticipantEntity::class, 'p')
+            ->join('p.stats', 'ps')
+            ->join('p.match', 'm')
+            ->where('p.summonerId = :puuid')
+            ->setParameter('puuid', $puuid)
+            ->getQuery()
+            ->getSingleResult();
+
+        $wins = (int) $this->em->createQueryBuilder()
+            ->select('COUNT(p.id)')
+            ->from(ParticipantEntity::class, 'p')
+            ->where('p.summonerId = :puuid')
+            ->andWhere('p.win = true')
+            ->setParameter('puuid', $puuid)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        $favoriteChampion = $this->em->createQueryBuilder()
+            ->select('p.championId, COUNT(p.id) as cnt')
+            ->from(ParticipantEntity::class, 'p')
+            ->where('p.summonerId = :puuid')
+            ->setParameter('puuid', $puuid)
+            ->groupBy('p.championId')
+            ->orderBy('cnt', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        $totalGames = (int) ($aggregates['totalGames'] ?? 0);
+        $avgCs = round((float) ($aggregates['avgCs'] ?? 0), 1);
+        $avgDurationSeconds = (int) round((float) ($aggregates['avgDuration'] ?? 0));
+        $avgDurationMinutes = $avgDurationSeconds > 0 ? $avgDurationSeconds / 60 : 1;
+
+        return [
+            'totalGames' => $totalGames,
+            'wins' => $wins,
+            'losses' => $totalGames - $wins,
+            'avgKills' => round((float) ($aggregates['avgKills'] ?? 0), 1),
+            'avgDeaths' => round((float) ($aggregates['avgDeaths'] ?? 0), 1),
+            'avgAssists' => round((float) ($aggregates['avgAssists'] ?? 0), 1),
+            'avgCs' => $avgCs,
+            'avgCsPerMin' => round($avgCs / $avgDurationMinutes, 1),
+            'avgGold' => (int) round((float) ($aggregates['avgGold'] ?? 0)),
+            'avgDurationSeconds' => $avgDurationSeconds,
+            'favoriteChampionId' => $favoriteChampion ? $favoriteChampion['championId'] : null,
+        ];
+    }
+}

--- a/src/Summoner/Presentation/Api/GetSummonerStatsController.php
+++ b/src/Summoner/Presentation/Api/GetSummonerStatsController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Summoner\Presentation\Api;
+
+use App\SharedContext\Application\Bus\QueryBusInterface;
+use App\Summoner\Application\Dto\SummonerStatsDto;
+use App\Summoner\Application\Query\GetSummonerStatsQuery;
+use App\Summoner\Domain\ValueObject\Puuid;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/{puuid}/stats', name: 'api_summoners_stats', methods: [Request::METHOD_GET])]
+final class GetSummonerStatsController extends AbstractController
+{
+    public function __construct(private readonly QueryBusInterface $queryBus)
+    {
+    }
+
+    public function __invoke(string $puuid): JsonResponse
+    {
+        /** @var SummonerStatsDto $stats */
+        $stats = $this->queryBus->handle(
+            new GetSummonerStatsQuery(Puuid::fromString($puuid))
+        );
+
+        return $this->json(['data' => $stats]);
+    }
+}


### PR DESCRIPTION
Introduces a SummonerMatchStatsProviderInterface port with a Doctrine adapter that aggregates match data per summoner in a single query. Exposes GET /api/admin/summoners/{puuid}/stats and renders the results as stat cards above the match history.