### PR TITLE
feat(summoner): add stats by position with win rate and KDA charts

### DIFF
--- a/assets/front/views/SummonerDetail.vue
+++ b/assets/front/views/SummonerDetail.vue
@@ -8,13 +8,15 @@ import { usePagination } from '@shared/composables/usePagination'
 import PaginationBar from '@shared/components/PaginationBar.vue'
 import SummonerStatsCards from '@shared/components/SummonerStatsCards.vue'
 import SummonerMatchCharts from '@shared/components/SummonerMatchCharts.vue'
+import PositionStatsChart from '@shared/components/PositionStatsChart.vue'
 import ChampionIcon from '@shared/components/ChampionIcon.vue'
-import type { Summoner, SummonerStats, Match } from '@shared/types'
+import type { Summoner, SummonerStats, PositionStat, Match } from '@shared/types'
 import { ChevronLeft, User, Star, Globe } from 'lucide-vue-next'
 
 const route = useRoute()
 const summoner = ref<Summoner | null>(null)
 const stats = ref<SummonerStats | null>(null)
+const positionStats = ref<PositionStat[]>([])
 const loading = ref(true)
 const error = ref<string | null>(null)
 
@@ -36,12 +38,14 @@ const {
 
 onMounted(async () => {
   try {
-    const [summonerRes, statsRes] = await Promise.all([
+    const [summonerRes, statsRes, positionRes] = await Promise.all([
       api.getSummoner(puuid),
       summonerApi.getStats(puuid),
+      summonerApi.getPositionStats(puuid),
     ])
     summoner.value = summonerRes.data
     stats.value = statsRes.data
+    positionStats.value = positionRes.data
     fetchPage(1)
   } catch (e) {
     error.value = 'Impossible de charger le profil'
@@ -125,6 +129,9 @@ function formatDate(dateString: string): string {
         :version="matches[0]?.version ?? ''"
         class="mb-2"
       />
+
+      <!-- Position stats -->
+      <PositionStatsChart v-if="positionStats.length > 0" :positions="positionStats" class="mb-6" />
 
       <!-- Charts & Match History -->
       <div v-if="matchesInitialLoading" class="loading">Chargement des parties…</div>

--- a/assets/shared/api/summonerApi.ts
+++ b/assets/shared/api/summonerApi.ts
@@ -1,4 +1,10 @@
-import type { Summoner, SummonerStats, ApiResponse, PaginatedResponse } from '@shared/types'
+import type {
+  Summoner,
+  SummonerStats,
+  PositionStat,
+  ApiResponse,
+  PaginatedResponse,
+} from '@shared/types'
 import { fetchApi } from './fetchApi'
 
 export const summonerApi = {
@@ -6,6 +12,8 @@ export const summonerApi = {
     fetchApi<PaginatedResponse<Summoner>>(`/summoners?page=${page}&limit=${limit}`),
   getSummoner: (puuid: string) => fetchApi<ApiResponse<Summoner>>(`/summoners/${puuid}`),
   getStats: (puuid: string) => fetchApi<ApiResponse<SummonerStats>>(`/summoners/${puuid}/stats`),
+  getPositionStats: (puuid: string) =>
+    fetchApi<ApiResponse<PositionStat[]>>(`/summoners/${puuid}/position-stats`),
   importByRiotId: (gameName: string, tagLine: string, platform: string) =>
     fetchApi<{ status: string; message: string }>('/summoners/import/riot-id', {
       method: 'POST',

--- a/assets/shared/components/PositionStatsChart.vue
+++ b/assets/shared/components/PositionStatsChart.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Bar } from 'vue-chartjs'
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Tooltip, Legend } from 'chart.js'
+import type { PositionStat } from '@shared/types'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend)
+
+const POSITION_LABELS: Record<string, string> = {
+  TOP: 'Top',
+  JUNGLE: 'Jungle',
+  MIDDLE: 'Mid',
+  BOTTOM: 'ADC',
+  UTILITY: 'Support',
+}
+
+const props = defineProps<{
+  positions: PositionStat[]
+}>()
+
+const labels = computed(() => props.positions.map((p) => POSITION_LABELS[p.position] ?? p.position))
+
+const winRateData = computed(() => ({
+  labels: labels.value,
+  datasets: [
+    {
+      label: 'Win Rate (%)',
+      data: props.positions.map((p) => p.winRate),
+      backgroundColor: props.positions.map((p) =>
+        p.winRate >= 50 ? 'rgba(30, 167, 253, 0.7)' : 'rgba(232, 64, 87, 0.7)',
+      ),
+      borderColor: props.positions.map((p) => (p.winRate >= 50 ? '#1ea7fd' : '#e84057')),
+      borderWidth: 1,
+      borderRadius: 4,
+    },
+  ],
+}))
+
+const kdaData = computed(() => ({
+  labels: labels.value,
+  datasets: [
+    {
+      label: 'Kills',
+      data: props.positions.map((p) => p.avgKills),
+      backgroundColor: 'rgba(30, 167, 253, 0.7)',
+      borderRadius: 4,
+    },
+    {
+      label: 'Deaths',
+      data: props.positions.map((p) => p.avgDeaths),
+      backgroundColor: 'rgba(232, 64, 87, 0.7)',
+      borderRadius: 4,
+    },
+    {
+      label: 'Assists',
+      data: props.positions.map((p) => p.avgAssists),
+      backgroundColor: 'rgba(200, 155, 60, 0.7)',
+      borderRadius: 4,
+    },
+  ],
+}))
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      labels: { color: '#a0aec0' },
+    },
+  },
+  scales: {
+    x: {
+      ticks: { color: '#a0aec0' },
+      grid: { color: 'rgba(255,255,255,0.05)' },
+    },
+    y: {
+      ticks: { color: '#a0aec0' },
+      grid: { color: 'rgba(255,255,255,0.05)' },
+    },
+  },
+}
+</script>
+
+<template>
+  <div class="card">
+    <div class="card-header">
+      <h3 class="font-semibold text-lol-text">Stats par rôle</h3>
+      <span class="text-lol-muted text-sm">{{ positions.length }} rôles joués</span>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 p-4">
+      <!-- Win Rate par rôle -->
+      <div>
+        <p class="text-lol-muted text-xs mb-2 text-center">Win Rate par rôle</p>
+        <div class="h-48">
+          <Bar :data="winRateData" :options="chartOptions" />
+        </div>
+      </div>
+
+      <!-- K/D/A par rôle -->
+      <div>
+        <p class="text-lol-muted text-xs mb-2 text-center">K/D/A moyen par rôle</p>
+        <div class="h-48">
+          <Bar :data="kdaData" :options="chartOptions" />
+        </div>
+      </div>
+    </div>
+
+    <!-- Tableau récapitulatif -->
+    <div class="overflow-x-auto px-4 pb-4">
+      <table class="table text-sm w-full">
+        <thead>
+          <tr>
+            <th>Rôle</th>
+            <th>Parties</th>
+            <th>Win Rate</th>
+            <th>KDA</th>
+            <th>Moy. CS</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="pos in positions" :key="pos.position">
+            <td class="font-medium text-lol-text">
+              {{ POSITION_LABELS[pos.position] ?? pos.position }}
+            </td>
+            <td class="text-lol-muted">{{ pos.totalGames }}</td>
+            <td>
+              <span
+                class="font-semibold"
+                :class="pos.winRate >= 50 ? 'text-lol-win' : 'text-lol-loss'"
+              >
+                {{ pos.winRate }}%
+              </span>
+            </td>
+            <td class="font-mono text-lol-text">
+              {{ pos.avgKills }} / {{ pos.avgDeaths }} / {{ pos.avgAssists }}
+              <span class="text-lol-muted text-xs ml-1">({{ pos.avgKda }})</span>
+            </td>
+            <td class="text-lol-muted">{{ pos.avgCs }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/assets/shared/types/index.ts
+++ b/assets/shared/types/index.ts
@@ -109,6 +109,18 @@ export interface SummonerStats {
   favoriteChampionId: number | null
 }
 
+export interface PositionStat {
+  position: string
+  totalGames: number
+  wins: number
+  winRate: number
+  avgKills: number
+  avgDeaths: number
+  avgAssists: number
+  avgKda: number
+  avgCs: number
+}
+
 export interface LeagueEntry {
   rank: number
   puuid: string

--- a/src/Summoner/Application/Dto/PositionStatsDto.php
+++ b/src/Summoner/Application/Dto/PositionStatsDto.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Summoner\Application\Dto;
+
+final readonly class PositionStatsDto
+{
+    public function __construct(
+        public string $position,
+        public int $totalGames,
+        public int $wins,
+        public float $winRate,
+        public float $avgKills,
+        public float $avgDeaths,
+        public float $avgAssists,
+        public float $avgKda,
+        public float $avgCs,
+    ) {
+    }
+}

--- a/src/Summoner/Application/Port/SummonerMatchStatsProviderInterface.php
+++ b/src/Summoner/Application/Port/SummonerMatchStatsProviderInterface.php
@@ -22,4 +22,17 @@ interface SummonerMatchStatsProviderInterface
      * }
      */
     public function getAggregateStatsByPuuid(string $puuid): array;
+
+    /**
+     * @return array<int, array{
+     *     position: string,
+     *     totalGames: int,
+     *     wins: int,
+     *     avgKills: float,
+     *     avgDeaths: float,
+     *     avgAssists: float,
+     *     avgCs: float,
+     * }>
+     */
+    public function getStatsByPositionByPuuid(string $puuid): array;
 }

--- a/src/Summoner/Application/Query/GetPositionStatsQuery.php
+++ b/src/Summoner/Application/Query/GetPositionStatsQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Summoner\Application\Query;
+
+use App\Summoner\Domain\ValueObject\Puuid;
+
+final readonly class GetPositionStatsQuery
+{
+    public function __construct(public Puuid $puuid)
+    {
+    }
+}

--- a/src/Summoner/Application/QueryHandler/GetPositionStatsHandler.php
+++ b/src/Summoner/Application/QueryHandler/GetPositionStatsHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Summoner\Application\QueryHandler;
+
+use App\Summoner\Application\Dto\PositionStatsDto;
+use App\Summoner\Application\Port\SummonerMatchStatsProviderInterface;
+use App\Summoner\Application\Query\GetPositionStatsQuery;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler(bus: 'query.bus')]
+final readonly class GetPositionStatsHandler
+{
+    public function __construct(
+        private SummonerMatchStatsProviderInterface $statsProvider,
+    ) {
+    }
+
+    /**
+     * @return PositionStatsDto[]
+     */
+    public function __invoke(GetPositionStatsQuery $query): array
+    {
+        $rows = $this->statsProvider->getStatsByPositionByPuuid($query->puuid->value());
+
+        return array_map(function (array $row): PositionStatsDto {
+            $totalGames = $row['totalGames'];
+            $wins = $row['wins'];
+            $avgKills = $row['avgKills'];
+            $avgDeaths = $row['avgDeaths'];
+            $avgAssists = $row['avgAssists'];
+
+            $winRate = $totalGames > 0
+                ? round($wins / $totalGames * 100, 1)
+                : 0.0;
+
+            $avgKda = $avgDeaths > 0
+                ? round(($avgKills + $avgAssists) / $avgDeaths, 2)
+                : round($avgKills + $avgAssists, 2);
+
+            return new PositionStatsDto(
+                position: $row['position'],
+                totalGames: $totalGames,
+                wins: $wins,
+                winRate: $winRate,
+                avgKills: $avgKills,
+                avgDeaths: $avgDeaths,
+                avgAssists: $avgAssists,
+                avgKda: $avgKda,
+                avgCs: $row['avgCs'],
+            );
+        }, $rows);
+    }
+}

--- a/src/Summoner/Infrastructure/Adapter/DoctrineMatchStatsAdapter.php
+++ b/src/Summoner/Infrastructure/Adapter/DoctrineMatchStatsAdapter.php
@@ -19,6 +19,7 @@ final readonly class DoctrineMatchStatsAdapter implements SummonerMatchStatsProv
         $aggregates = $this->em->createQueryBuilder()
             ->select([
                 'COUNT(p.id) as totalGames',
+                'SUM(CASE WHEN p.win = true THEN 1 ELSE 0 END) as wins',
                 'AVG(p.kills) as avgKills',
                 'AVG(p.deaths) as avgDeaths',
                 'AVG(p.assists) as avgAssists',
@@ -34,15 +35,6 @@ final readonly class DoctrineMatchStatsAdapter implements SummonerMatchStatsProv
             ->getQuery()
             ->getSingleResult();
 
-        $wins = (int) $this->em->createQueryBuilder()
-            ->select('COUNT(p.id)')
-            ->from(ParticipantEntity::class, 'p')
-            ->where('p.summonerId = :puuid')
-            ->andWhere('p.win = true')
-            ->setParameter('puuid', $puuid)
-            ->getQuery()
-            ->getSingleScalarResult();
-
         $favoriteChampion = $this->em->createQueryBuilder()
             ->select('p.championId, COUNT(p.id) as cnt')
             ->from(ParticipantEntity::class, 'p')
@@ -55,9 +47,10 @@ final readonly class DoctrineMatchStatsAdapter implements SummonerMatchStatsProv
             ->getOneOrNullResult();
 
         $totalGames = (int) ($aggregates['totalGames'] ?? 0);
+        $wins = (int) ($aggregates['wins'] ?? 0);
         $avgCs = round((float) ($aggregates['avgCs'] ?? 0), 1);
         $avgDurationSeconds = (int) round((float) ($aggregates['avgDuration'] ?? 0));
-        $avgDurationMinutes = $avgDurationSeconds > 0 ? $avgDurationSeconds / 60 : 1;
+        $avgCsPerMin = $avgDurationSeconds > 0 ? round($avgCs / ($avgDurationSeconds / 60), 1) : 0.0;
 
         return [
             'totalGames' => $totalGames,
@@ -67,10 +60,52 @@ final readonly class DoctrineMatchStatsAdapter implements SummonerMatchStatsProv
             'avgDeaths' => round((float) ($aggregates['avgDeaths'] ?? 0), 1),
             'avgAssists' => round((float) ($aggregates['avgAssists'] ?? 0), 1),
             'avgCs' => $avgCs,
-            'avgCsPerMin' => round($avgCs / $avgDurationMinutes, 1),
+            'avgCsPerMin' => $avgCsPerMin,
             'avgGold' => (int) round((float) ($aggregates['avgGold'] ?? 0)),
             'avgDurationSeconds' => $avgDurationSeconds,
             'favoriteChampionId' => $favoriteChampion ? $favoriteChampion['championId'] : null,
         ];
+    }
+
+    public function getStatsByPositionByPuuid(string $puuid): array
+    {
+        $rows = $this->em->createQueryBuilder()
+            ->select([
+                'ps.individualPosition as position',
+                'COUNT(p.id) as totalGames',
+                'SUM(CASE WHEN p.win = true THEN 1 ELSE 0 END) as wins',
+                'AVG(p.kills) as avgKills',
+                'AVG(p.deaths) as avgDeaths',
+                'AVG(p.assists) as avgAssists',
+                'AVG(ps.cs) as avgCs',
+            ])
+            ->from(ParticipantEntity::class, 'p')
+            ->join('p.stats', 'ps')
+            ->where('p.summonerId = :puuid')
+            ->andWhere('ps.individualPosition != :empty')
+            ->setParameter('puuid', $puuid)
+            ->setParameter('empty', '')
+            ->groupBy('ps.individualPosition')
+            ->orderBy('totalGames', 'DESC')
+            ->getQuery()
+            ->getArrayResult();
+
+        return array_map(function (array $row): array {
+            $totalGames = (int) $row['totalGames'];
+            $wins = (int) $row['wins'];
+            $avgKills = round((float) $row['avgKills'], 1);
+            $avgDeaths = round((float) $row['avgDeaths'], 1);
+            $avgAssists = round((float) $row['avgAssists'], 1);
+
+            return [
+                'position' => $row['position'],
+                'totalGames' => $totalGames,
+                'wins' => $wins,
+                'avgKills' => $avgKills,
+                'avgDeaths' => $avgDeaths,
+                'avgAssists' => $avgAssists,
+                'avgCs' => round((float) $row['avgCs'], 1),
+            ];
+        }, $rows);
     }
 }

--- a/src/Summoner/Presentation/Api/GetPositionStatsController.php
+++ b/src/Summoner/Presentation/Api/GetPositionStatsController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Summoner\Presentation\Api;
+
+use App\SharedContext\Application\Bus\QueryBusInterface;
+use App\Summoner\Application\Query\GetPositionStatsQuery;
+use App\Summoner\Domain\ValueObject\Puuid;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/{puuid}/position-stats', name: 'api_summoners_position_stats', methods: [Request::METHOD_GET])]
+final class GetPositionStatsController extends AbstractController
+{
+    public function __construct(private readonly QueryBusInterface $queryBus)
+    {
+    }
+
+    public function __invoke(string $puuid): JsonResponse
+    {
+        $positions = $this->queryBus->handle(
+            new GetPositionStatsQuery(Puuid::fromString($puuid))
+        );
+
+        return $this->json(['data' => $positions]);
+    }
+}


### PR DESCRIPTION
- New GET /{puuid}/position-stats endpoint (grouped by individualPosition)
- PositionStatsDto, GetPositionStatsQuery, GetPositionStatsHandler
- DoctrineMatchStatsAdapter: getStatsByPositionByPuuid + refactor fixes (merge wins into main query, fix avgCsPerMin calculation)
- PositionStatsChart.vue: win rate bar chart + KDA grouped bar chart + summary table
- SummonerDetail.vue: load position stats in parallel, display above match history