### PR TITLE
refactor(summoner): extract StatsCalculator and clean up stats handlers

### DIFF
--- a/src/Summoner/Application/Dto/SummonerStatsDto.php
+++ b/src/Summoner/Application/Dto/SummonerStatsDto.php
@@ -21,33 +21,4 @@ final readonly class SummonerStatsDto
         public ?int $favoriteChampionId,
     ) {
     }
-
-    /**
-     * @param array{totalGames: int, wins: int, losses: int, avgKills: float, avgDeaths: float, avgAssists: float, avgCs: float, avgCsPerMin: float, avgGold: int, avgDurationSeconds: int, favoriteChampionId: int|null} $data
-     */
-    public static function fromArray(array $data): self
-    {
-        $winRate = $data['totalGames'] > 0
-            ? round($data['wins'] / $data['totalGames'] * 100, 1)
-            : 0.0;
-
-        $avgKda = $data['avgDeaths'] > 0
-            ? round(($data['avgKills'] + $data['avgAssists']) / $data['avgDeaths'], 2)
-            : round($data['avgKills'] + $data['avgAssists'], 2);
-
-        return new self(
-            totalGames: $data['totalGames'],
-            wins: $data['wins'],
-            losses: $data['losses'],
-            winRate: $winRate,
-            avgKills: $data['avgKills'],
-            avgDeaths: $data['avgDeaths'],
-            avgAssists: $data['avgAssists'],
-            avgKda: $avgKda,
-            avgCs: $data['avgCs'],
-            avgCsPerMin: $data['avgCsPerMin'],
-            avgGold: $data['avgGold'],
-            favoriteChampionId: $data['favoriteChampionId'],
-        );
-    }
 }

--- a/src/Summoner/Application/QueryHandler/GetPositionStatsHandler.php
+++ b/src/Summoner/Application/QueryHandler/GetPositionStatsHandler.php
@@ -7,6 +7,7 @@ namespace App\Summoner\Application\QueryHandler;
 use App\Summoner\Application\Dto\PositionStatsDto;
 use App\Summoner\Application\Port\SummonerMatchStatsProviderInterface;
 use App\Summoner\Application\Query\GetPositionStatsQuery;
+use App\Summoner\Application\StatsCalculator;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler(bus: 'query.bus')]
@@ -24,32 +25,16 @@ final readonly class GetPositionStatsHandler
     {
         $rows = $this->statsProvider->getStatsByPositionByPuuid($query->puuid->value());
 
-        return array_map(function (array $row): PositionStatsDto {
-            $totalGames = $row['totalGames'];
-            $wins = $row['wins'];
-            $avgKills = $row['avgKills'];
-            $avgDeaths = $row['avgDeaths'];
-            $avgAssists = $row['avgAssists'];
-
-            $winRate = $totalGames > 0
-                ? round($wins / $totalGames * 100, 1)
-                : 0.0;
-
-            $avgKda = $avgDeaths > 0
-                ? round(($avgKills + $avgAssists) / $avgDeaths, 2)
-                : round($avgKills + $avgAssists, 2);
-
-            return new PositionStatsDto(
-                position: $row['position'],
-                totalGames: $totalGames,
-                wins: $wins,
-                winRate: $winRate,
-                avgKills: $avgKills,
-                avgDeaths: $avgDeaths,
-                avgAssists: $avgAssists,
-                avgKda: $avgKda,
-                avgCs: $row['avgCs'],
-            );
-        }, $rows);
+        return array_map(static fn (array $row): PositionStatsDto => new PositionStatsDto(
+            position: $row['position'],
+            totalGames: $row['totalGames'],
+            wins: $row['wins'],
+            winRate: StatsCalculator::winRate($row['wins'], $row['totalGames']),
+            avgKills: $row['avgKills'],
+            avgDeaths: $row['avgDeaths'],
+            avgAssists: $row['avgAssists'],
+            avgKda: StatsCalculator::avgKda($row['avgKills'], $row['avgDeaths'], $row['avgAssists']),
+            avgCs: $row['avgCs'],
+        ), $rows);
     }
 }

--- a/src/Summoner/Application/QueryHandler/GetSummonerStatsHandler.php
+++ b/src/Summoner/Application/QueryHandler/GetSummonerStatsHandler.php
@@ -7,6 +7,7 @@ namespace App\Summoner\Application\QueryHandler;
 use App\Summoner\Application\Dto\SummonerStatsDto;
 use App\Summoner\Application\Port\SummonerMatchStatsProviderInterface;
 use App\Summoner\Application\Query\GetSummonerStatsQuery;
+use App\Summoner\Application\StatsCalculator;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler(bus: 'query.bus')]
@@ -21,6 +22,19 @@ final readonly class GetSummonerStatsHandler
     {
         $data = $this->statsProvider->getAggregateStatsByPuuid($query->puuid->value());
 
-        return SummonerStatsDto::fromArray($data);
+        return new SummonerStatsDto(
+            totalGames: $data['totalGames'],
+            wins: $data['wins'],
+            losses: $data['losses'],
+            winRate: StatsCalculator::winRate($data['wins'], $data['totalGames']),
+            avgKills: $data['avgKills'],
+            avgDeaths: $data['avgDeaths'],
+            avgAssists: $data['avgAssists'],
+            avgKda: StatsCalculator::avgKda($data['avgKills'], $data['avgDeaths'], $data['avgAssists']),
+            avgCs: $data['avgCs'],
+            avgCsPerMin: $data['avgCsPerMin'],
+            avgGold: $data['avgGold'],
+            favoriteChampionId: $data['favoriteChampionId'],
+        );
     }
 }

--- a/src/Summoner/Application/StatsCalculator.php
+++ b/src/Summoner/Application/StatsCalculator.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Summoner\Application;
+
+final class StatsCalculator
+{
+    public static function winRate(int $wins, int $totalGames): float
+    {
+        return $totalGames > 0
+            ? round($wins / $totalGames * 100, 1)
+            : 0.0;
+    }
+
+    public static function avgKda(float $kills, float $deaths, float $assists): float
+    {
+        return $deaths > 0
+            ? round(($kills + $assists) / $deaths, 2)
+            : round($kills + $assists, 2);
+    }
+}

--- a/src/Summoner/Infrastructure/Adapter/DoctrineMatchStatsAdapter.php
+++ b/src/Summoner/Infrastructure/Adapter/DoctrineMatchStatsAdapter.php
@@ -90,22 +90,14 @@ final readonly class DoctrineMatchStatsAdapter implements SummonerMatchStatsProv
             ->getQuery()
             ->getArrayResult();
 
-        return array_map(function (array $row): array {
-            $totalGames = (int) $row['totalGames'];
-            $wins = (int) $row['wins'];
-            $avgKills = round((float) $row['avgKills'], 1);
-            $avgDeaths = round((float) $row['avgDeaths'], 1);
-            $avgAssists = round((float) $row['avgAssists'], 1);
-
-            return [
-                'position' => $row['position'],
-                'totalGames' => $totalGames,
-                'wins' => $wins,
-                'avgKills' => $avgKills,
-                'avgDeaths' => $avgDeaths,
-                'avgAssists' => $avgAssists,
-                'avgCs' => round((float) $row['avgCs'], 1),
-            ];
-        }, $rows);
+        return array_map(static fn (array $row): array => [
+            'position' => $row['position'],
+            'totalGames' => (int) $row['totalGames'],
+            'wins' => (int) $row['wins'],
+            'avgKills' => round((float) $row['avgKills'], 1),
+            'avgDeaths' => round((float) $row['avgDeaths'], 1),
+            'avgAssists' => round((float) $row['avgAssists'], 1),
+            'avgCs' => round((float) $row['avgCs'], 1),
+        ], $rows);
     }
 }

--- a/src/Summoner/Presentation/Api/GetSummonerByPuuidController.php
+++ b/src/Summoner/Presentation/Api/GetSummonerByPuuidController.php
@@ -10,6 +10,7 @@ use App\Summoner\Application\Query\GetSummonerByPuuidQuery;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/{puuid}', name: 'api_summoners_show', methods: [Request::METHOD_GET])]
@@ -26,7 +27,7 @@ final class GetSummonerByPuuidController extends AbstractController
         $summoner = $this->queryBus->handle(new GetSummonerByPuuidQuery($puuid));
 
         if (null === $summoner) {
-            return $this->json(['error' => 'Summoner not found'], 404);
+            return $this->json(['error' => 'Summoner not found'], Response::HTTP_NOT_FOUND);
         }
 
         return $this->json([


### PR DESCRIPTION
- Add StatsCalculator with static winRate() and avgKda() methods
- Remove business logic from SummonerStatsDto (drop fromArray())
- GetSummonerStatsHandler and GetPositionStatsHandler now use StatsCalculator
- Replace verbose array_map closures with static arrow functions
- Fix raw 404 integer to Response::HTTP_NOT_FOUND in GetSummonerByPuuidController