### PR TITLE
fix(deploy): correct volume mount paths in compose.devtest.yaml

### DIFF
--- a/compose.devtest.yaml
+++ b/compose.devtest.yaml
@@ -29,7 +29,8 @@ services:
     volumes:
       - caddy_data:/data
       - caddy_config:/config
-      - jwt_keys:/var/www/html/config/jwt
+      - jwt_keys:/app/config/jwt
+      - app_var:/app/var
       - public_images:/app/public/images
     # Plus de ports exposés directement — Traefik s'en charge
     networks:
@@ -64,7 +65,8 @@ services:
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
       MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
     volumes:
-      - jwt_keys:/var/www/html/config/jwt
+      - jwt_keys:/app/config/jwt
+      - app_var:/app/var
       - public_images:/app/public/images
     networks:
       - internal
@@ -140,6 +142,7 @@ volumes:
   jwt_keys:
   rabbitmq_data:
   public_images:
+  app_var:
 
 networks:
   web-network:


### PR DESCRIPTION
- jwt_keys: /var/www/html/config/jwt → /app/config/jwt (WORKDIR is /app) JWT keys were never persisted and regenerated on every restart
- app_var:/app/var added on php and worker to replace anonymous volumes created by VOLUME /app/var/ in Dockerfile, which accumulated on each deploy